### PR TITLE
feat: add placeholder removal reasons to corpus API admin graph

### DIFF
--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -65,6 +65,28 @@ enum RejectionReason {
 }
 
 """
+2024-01-23
+
+these reasons are used when dismissing prospects only for the
+SLATE_SCHEDULER prospect type. this is a preliminary step towards ML
+scheduling items, and this reason set will *likely* be used when removing ML
+scheduled items as well.
+
+these reasons *may* also be used more widely in the prospecting view in the
+future, but would be blocked on removal count going down significantly.
+
+as of today, 2024-01-23, these reasons are placeholders while ML & editorial
+finalize the preliminary set.
+"""
+enum RemovalReason {
+    TOPIC
+    PUBLISHER
+    INAPPROPRIATE
+    REDUNDANT
+    OUTDATED
+}
+
+"""
 Prospect types. This enum is not used anywhere in this schema, however it is used
 by the Curation Admin Tools frontend to filter prospects.
 """


### PR DESCRIPTION
## Goal

adding placeholder removal reasons to corpus API to unblock the admin tool. these reasons will be updated as soon as they have been finalized by editorial & ML.

note that this doesn't need to go to prod now - reviewing this and going to dev is enough to continue development on the feature. i'd recommend we don't go to prod until we need to.

## I'd love feedback/perspectives on:

- any issues we see with introducing these placeholder values into the admin graph? as no clients will use them as inputs yet, graph updates shouldn't complain.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-457