### PR TITLE
fix(ProspectAPI): fix the iam permissions to get the queue url.

### DIFF
--- a/infrastructure/prospect-api/src/bridgeSqsLambda.ts
+++ b/infrastructure/prospect-api/src/bridgeSqsLambda.ts
@@ -80,7 +80,7 @@ export class BridgeSqsLambda extends Construct {
         statement: [
           {
             effect: 'Allow',
-            actions: ['sqs:SendMessage', 'sqs:GetQueueAttributes'],
+            actions: ['sqs:SendMessage', 'sqs:GetQueueAttributes', 'sqs:GetQueueUrl'],
             resources: [sqsLambda.sqsQueueResource.arn],
           },
         ],


### PR DESCRIPTION
## Goal

Fix the IAM role to allow get_queue_url to run as expected.