### PR TITLE
feat(ProspectApi): [MC-629] GCP Metaflow can put events in EventBridge

### DIFF
--- a/infrastructure/prospect-api/src/config/index.ts
+++ b/infrastructure/prospect-api/src/config/index.ts
@@ -52,6 +52,7 @@ export const config = {
   },
   envVars: {
     eventBusName: `PocketEventBridge-${environment}-Shared-Event-Bus`,
+    eventDetailType: 'prospect-generation',
     metaflowFirehoseName,
     snowplowEndpoint,
   },

--- a/lambdas/prospect-api-bridge-lambda/src/config.ts
+++ b/lambdas/prospect-api-bridge-lambda/src/config.ts
@@ -8,7 +8,7 @@ const config = {
         process.env.EVENT_BRIDGE_BUS_NAME ||
         'PocketEventBridge-local-Shared-Event-Bus',
       source: 'prospect-events',
-      detailType: 'prospect-generation',
+      detailType: process.env.EVENT_BRIDGE_DETAIL_TYPE || 'prospect-generation',
     },
     firehose: {
       deliveryStreamName:


### PR DESCRIPTION
## Goal
Simplify the Content Platform prospect data flow, by sending prospects directly from GCP Metaflow to EventBridge.

## Implementation Decisions
I didn't remove the code that sends prospects to EventBridge from the Lambda to avoid disruption. That means we're be double-sending prospects for a short period, which is OK because prospect generation events are idempotent.

## Deployment steps

- [x] Deploy this PR
- [ ] Test sending prospects to EventBridge from GCP
- [ ] Stop sending prospects to EventBridge from Lambda in a future PR

## References

- https://mozilla-hub.atlassian.net/browse/MC-629
- [Slack thread](https://mozilla.slack.com/archives/C05G12U8N1H/p1707234444434649?thread_ts=1707163737.382669&cid=C05G12U8N1H) on simplifying prospecting pipeline