### PR TITLE
chore(snowplow): [MC-524] Update the collector endpoint for Snowplow

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -12,7 +12,7 @@ const githubConnectionArn = isDev
   : 'arn:aws:codestar-connections:us-east-1:996905175585:connection/5fa5aa2b-a2d2-43e3-ab5a-72ececfc1870';
 const snowplowEndpoint = isDev
   ? 'com-getpocket-prod1.mini.snplow.net'
-  : 'com-getpocket-prod1.collector.snplow.net';
+  : 'd.getpocket.com';
 
 const rds = {
   minCapacity: isDev ? 1 : 8,

--- a/infrastructure/prospect-api/src/config/index.ts
+++ b/infrastructure/prospect-api/src/config/index.ts
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'development') {
 
 const snowplowEndpoint = isDev
   ? 'com-getpocket-prod1.mini.snplow.net'
-  : 'com-getpocket-prod1.collector.snplow.net';
+  : 'd.getpocket.com';
 
 // Firehose infra-as-code is defined in AWS Metaflow CloudFormation for production and development, respectively:
 // https://github.com/Pocket/cloudformation-templates/blob/main/service/MetaflowTools/parameters_prod.json#L92


### PR DESCRIPTION
## Goal

Now pointing to `d.getpocket.com` which provides outage protection. 

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-524