### PR TITLE
Revert "Merge pull request #55 from Pocket/security-alert-faker-package"

### DIFF
--- a/packages/prospectapi-common/package.json
+++ b/packages/prospectapi-common/package.json
@@ -18,18 +18,18 @@
     "@aws-sdk/client-dynamodb": "3.504.0",
     "@aws-sdk/lib-dynamodb": "3.504.0",
     "@sentry/node": "6.19.7",
+    "@faker-js/faker": "6.3.1",
+    "graphql-tag": "2.12.6",
     "cross-fetch": "3.1.5",
     "fetch-retry": "5.0.6",
-    "graphql-tag": "2.12.6",
     "tldts": "5.7.87"
   },
   "devDependencies": {
-    "@faker-js/faker": "8.4.0",
-    "@types/jest": "29.5.12",
     "eslint-config-custom": "workspace:*",
-    "jest": "29.7.0",
+    "tsconfig": "workspace:*",
+    "@types/jest": "29.5.12",
     "msw": "2.1.2",
-    "ts-jest": "29.1.2",
-    "tsconfig": "workspace:*"
+    "jest": "29.7.0",
+    "ts-jest": "29.1.2"
   }
 }

--- a/packages/prospectapi-common/test/helpers.ts
+++ b/packages/prospectapi-common/test/helpers.ts
@@ -23,29 +23,29 @@ export const createProspect = (
   curated = false,
 ): Prospect => {
   // randomize number of authors
-  const authorCount = faker.number.int({ min: 1, max: 3 });
+  const authorCount = faker.datatype.number({ min: 1, max: 3 });
   const authors: string[] = [];
 
   for (let i = 0; i < authorCount; i++) {
-    authors.push(faker.person.fullName());
+    authors.push(faker.name.findName());
   }
 
   return {
-    id: faker.string.uuid(),
-    prospectId: faker.string.uuid(),
+    id: faker.datatype.uuid(),
+    prospectId: faker.datatype.uuid(),
     scheduledSurfaceGuid,
-    topic: faker.helpers.arrayElement(topicsArray),
+    topic: faker.random.arrayElement(topicsArray),
     prospectType,
     url: faker.internet.url(),
-    rank: faker.number.int({ min: 1, max: 100000 }),
-    saveCount: faker.number.int({ min: 1, max: 100000000 }),
+    rank: faker.datatype.number(),
+    saveCount: faker.datatype.number(),
     curated,
     createdAt: Math.floor(faker.date.recent().valueOf() / 1000),
     domain: faker.internet.domainName(),
     excerpt: faker.lorem.paragraph(),
     imageUrl: faker.internet.url(),
-    language: faker.helpers.arrayElement(Object.values(CorpusLanguage)),
-    publisher: faker.helpers.arrayElement([
+    language: faker.random.arrayElement(Object.values(CorpusLanguage)),
+    publisher: faker.random.arrayElement([
       'The New York Times',
       'The Atlantic',
       'The Guardian',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       turbo:
         specifier: latest
-        version: 1.12.3
+        version: 1.12.2
 
   infrastructure/curated-corpus-api:
     dependencies:
@@ -166,6 +166,9 @@ importers:
       '@aws-sdk/lib-dynamodb':
         specifier: 3.504.0
         version: 3.504.0(@aws-sdk/client-dynamodb@3.504.0)
+      '@faker-js/faker':
+        specifier: 6.3.1
+        version: 6.3.1
       '@sentry/node':
         specifier: 6.19.7
         version: 6.19.7
@@ -182,9 +185,6 @@ importers:
         specifier: 5.7.87
         version: 5.7.87
     devDependencies:
-      '@faker-js/faker':
-        specifier: 8.4.0
-        version: 8.4.0
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
@@ -289,8 +289,11 @@ importers:
         specifier: ^3.341.0
         version: 3.496.0
       '@faker-js/faker':
-        specifier: 8.4.0
-        version: 8.4.0
+        specifier: 8.0.2
+        version: 8.0.2
+      '@types/faker':
+        specifier: 6.6.8
+        version: 6.6.8
       '@types/graphql-upload':
         specifier: 8.0.12
         version: 8.0.12
@@ -356,11 +359,14 @@ importers:
         version: 6.3.3
     devDependencies:
       '@faker-js/faker':
-        specifier: 8.4.0
-        version: 8.4.0
+        specifier: 8.0.2
+        version: 8.0.2
       '@types/chai-spies':
         specifier: 1.0.3
         version: 1.0.3
+      '@types/faker':
+        specifier: 6.6.8
+        version: 6.6.8
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
@@ -2864,8 +2870,13 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@faker-js/faker@8.4.0:
-    resolution: {integrity: sha512-htW87352wzUCdX1jyUQocUcmAaFqcR/w082EC8iP/gtkF0K+aKcBp0hR5Arb7dzR8tQ1TrhE9DNa5EbJELm84w==}
+  /@faker-js/faker@6.3.1:
+    resolution: {integrity: sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    dev: false
+
+  /@faker-js/faker@8.0.2:
+    resolution: {integrity: sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
     dev: true
 
@@ -4959,6 +4970,12 @@ packages:
       '@types/express-serve-static-core': 4.17.41
       '@types/qs': 6.9.11
       '@types/serve-static': 1.15.5
+
+  /@types/faker@6.6.8:
+    resolution: {integrity: sha512-9moiFKhmFMlI/7v5jVsPS8bbtIN1Rfo03hTPf1HPgWnZCksDup2xDTyBVC6xzjmUL/i6N6ecOJQIj5LrVJbYcg==}
+    dependencies:
+      faker: 6.6.6
+    dev: true
 
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -7260,7 +7277,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.4.0-dev.20240207
+      typescript: 5.4.0-dev.20240202
     dev: false
 
   /drange@1.1.1:
@@ -8152,6 +8169,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /faker@6.6.6:
+    resolution: {integrity: sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==}
+    dev: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -13258,64 +13279,64 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /turbo-darwin-64@1.12.3:
-    resolution: {integrity: sha512-dDglIaux+A4jOnB9CDH69sujmrnuLJLrKw1t3J+if6ySlFuxSwC++gDq9TVuOZo2+S7lFkGh+x5ytn3wp+jE8Q==}
+  /turbo-darwin-64@1.12.2:
+    resolution: {integrity: sha512-Aq/ePQ5KNx6XGwlZWTVTqpQYfysm1vkwkI6kAYgrX5DjMWn+tUXrSgNx4YNte0F+V4DQ7PtuWX+jRG0h0ZNg0A==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64@1.12.3:
-    resolution: {integrity: sha512-5TqqeujEyHMoVUWGzSzUl5ERSg7HDCdbU3gBs5ziWTpFRpeJ/+Y15kYyZJcMQcubRIH3Y1hL/yA5IhlGdgXOMA==}
+  /turbo-darwin-arm64@1.12.2:
+    resolution: {integrity: sha512-wTr+dqkwJo/eXE+4SPTSeNBKyyfQJhI6I9sKVlCSBmtaNEqoGNgdVzgMUdqrg9AIFzLIiKO+zhfskNaSWpVFow==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64@1.12.3:
-    resolution: {integrity: sha512-yUreU+/gq4vlBtcdyfjz7slwz4zM1RG8sSXvyHmAS+QXqSrGkegg4qLl2fRbv/c3EyA/XbfcZuD6tcrXkejr6g==}
+  /turbo-linux-64@1.12.2:
+    resolution: {integrity: sha512-BggBKrLojGarDaa2zBo+kUR3fmjpd6bLA8Unm3Aa2oJw0UvEi3Brd+w9lNsPZHXXQYBUzNUY2gCdxf3RteWb0g==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64@1.12.3:
-    resolution: {integrity: sha512-XRwAsp2eRSqZmaMVNrmHoKqofeJMuD87zmefZLTRAObh38hIwKgyl2QRsJIbteob5RN77yFbv3lAJ36UIY5h7w==}
+  /turbo-linux-arm64@1.12.2:
+    resolution: {integrity: sha512-v/apSRvVuwYjq1D9MJFsHv2EpGd1S4VoSdZvVfW6FaM06L8CFZa92urNR1svdGYN28YVKwK9Ikc9qudC6t/d5A==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64@1.12.3:
-    resolution: {integrity: sha512-CPnRfnUCtmFeShOtUdMCthySjmyHaoTyh9JueiYFvtCNeO3WfDMj63dpOQstQWHdJFYmIrIGfhAclcds9ePQYA==}
+  /turbo-windows-64@1.12.2:
+    resolution: {integrity: sha512-3uDdwXcRGkgopYFdPDpxQiuQjfQ12Fxq0fhj+iGymav0eWA4W4wzYwSdlUp6rT22qOBIzaEsrIspRwx1DsMkNg==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64@1.12.3:
-    resolution: {integrity: sha512-cYA/wlzvp4vlCNHYJ2AjNS3FLXWwUC/5CJompBkTeKFFB6AviE/iLkbIhFikCVSNXZk/3AGanpMUXIkt3bdlwg==}
+  /turbo-windows-arm64@1.12.2:
+    resolution: {integrity: sha512-zNIHnwtQfJSjFi7movwhPQh2rfrcKZ7Xv609EN1yX0gEp9GxooCUi2yNnBQ8wTqFjioA2M5hZtGJQ0RrKaEm/Q==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo@1.12.3:
-    resolution: {integrity: sha512-a6q8I0TK9ohACYbkmxzG/JYPuDC4VCvfmXLTlf321qQ4BIAhoyaOj/O2g+zJ6L1vNYnZ82G4LrbMfgLLngbLsg==}
+  /turbo@1.12.2:
+    resolution: {integrity: sha512-BcoQjBZ+LJCMdjzWhzQflOinUjek28rWXj07aaaAQ8T3Ehs0JFSjIsXOm4qIbo52G4xk3gFVcUtJhh/QRADl7g==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.12.3
-      turbo-darwin-arm64: 1.12.3
-      turbo-linux-64: 1.12.3
-      turbo-linux-arm64: 1.12.3
-      turbo-windows-64: 1.12.3
-      turbo-windows-arm64: 1.12.3
+      turbo-darwin-64: 1.12.2
+      turbo-darwin-arm64: 1.12.2
+      turbo-linux-64: 1.12.2
+      turbo-linux-arm64: 1.12.2
+      turbo-windows-64: 1.12.2
+      turbo-windows-arm64: 1.12.2
     dev: true
 
   /type-check@0.4.0:
@@ -13442,8 +13463,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.4.0-dev.20240207:
-    resolution: {integrity: sha512-BD7gF4QnjiTzOPqstgkgBxANkltT6VsZS6gFjXf7haPWTgrcebvCNQr1yGazb0o18RVtNXeHs6lDbXKqhJhiQQ==}
+  /typescript@5.4.0-dev.20240202:
+    resolution: {integrity: sha512-z7JmYSrDsCg9yCfckUT1KAFc6QbUzSYOArsclCqLUJVMxmCIC1pqHOe01DN1qQ2yz8Loj693uU8mH88jQ/BT8A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false

--- a/servers/curated-corpus-api/package.json
+++ b/servers/curated-corpus-api/package.json
@@ -50,19 +50,20 @@
   },
   "devDependencies": {
     "@aws-sdk/types": "^3.341.0",
-    "@faker-js/faker": "8.4.0",
+    "@faker-js/faker": "8.0.2",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
+    "@types/faker": "6.6.8",
     "@types/graphql-upload": "8.0.12",
     "@types/jest": "29.5.12",
     "@types/node": "^20.11.6",
-    "eslint-config-custom": "workspace:*",
     "form-data": "4.0.0",
     "jest": "29.7.0",
     "nock": "13.5.1",
     "nodemon": "3.0.1",
     "prisma": "^4.16.1",
     "supertest": "6.3.4",
-    "ts-jest": "29.1.2",
-    "tsconfig": "workspace:*"
+    "ts-jest": "29.1.2"
   },
   "files": [
     "dist",

--- a/servers/prospect-api/package.json
+++ b/servers/prospect-api/package.json
@@ -28,16 +28,17 @@
     "supertest": "^6.3.3"
   },
   "devDependencies": {
-    "@faker-js/faker": "8.4.0",
+    "@faker-js/faker": "8.0.2",
+    "eslint-config-custom": "workspace:*",
+    "tsconfig": "workspace:*",
+    "@types/faker": "6.6.8",
     "@types/chai-spies": "1.0.3",
     "@types/jest": "29.5.12",
     "@types/lodash": "4.14.182",
-    "eslint-config-custom": "workspace:*",
     "jest": "29.7.0",
     "lodash": "4.17.21",
     "nodemon": "2.0.22",
-    "ts-jest": "29.1.2",
-    "tsconfig": "workspace:*"
+    "ts-jest": "29.1.2"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Goal
Get the Prospect API Translation Lambda to work again, and get prospects flowing into the tool.

> Error: Cannot find module '@faker-js/faker'\nRequire stack:\n- /var/task/node_modules/prospectapi-common/dist/test/helpers.js\n- /var/task/node_modules/prospectapi-common/dist/index.js\n- /var/task/index.js\n- /var/runtime/index.mjs

![image](https://github.com/Pocket/content-monorepo/assets/1547251/aece71cf-d0cb-49cf-a215-db1a612ecbb0)


## Implementation Decisions
This reverts commit 788e65722e98ee55350d77d386a5f0661c590791, reversing changes made to 846707477bcac91c0449c21d1089eaf2a4ff061a.

## References

- [MC-667](https://mozilla-hub.atlassian.net/browse/MC-667)
- [Slack thread](https://mozilla.slack.com/archives/C06G5D04B9D/p1707505595359769)

[MC-667]: https://mozilla-hub.atlassian.net/browse/MC-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ