### PR TITLE
feat: accept reason & comment in CreateApprovedCorpusItem mutation

### DIFF
--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -624,11 +624,11 @@ input CreateApprovedCorpusItemInput {
   """
   A comma-separated list of reasons for manually adding an item (only supplied when `source` is MANUAL).
   """
-  reasons: String
+  manualAdditionReasons: String
   """
-  Free-text entered by the curator to give further detail to the reason(s) provided.
+  Free-text entered by the curator to give further detail to the manual addition reason(s) provided.
   """
-  reasonComment: String
+  manualAdditionReasonComment: String
 }
 
 """


### PR DESCRIPTION
## Goal

accept an optional `reason` and `reasonComment` when creating an approved corpus item.

this PR only allows the new fields in to the mutation. usage of this data will be accomplished in a follow-up ticket once the snowplow schema is updated.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-632