### PR TITLE
fix: allow underscores when sanitizing text

### DIFF
--- a/packages/content-common/index.spec.ts
+++ b/packages/content-common/index.spec.ts
@@ -36,7 +36,7 @@ describe('content-common', () => {
 
   describe('sanitizeText', () => {
     it('should not modify a string when it satisfies our conditions already', () => {
-      const string = 'A string! That conforms. To the regex? YES. 20!';
+      const string = 'A string! That conforms. To the regex? YES_IT_DOES. 20!';
 
       expect(sanitizeText(string, maxStringLength)).toEqual(string);
     });

--- a/packages/content-common/index.ts
+++ b/packages/content-common/index.ts
@@ -36,7 +36,7 @@ export const parseReasonsCsv = (
  */
 export const sanitizeText = (input: string, maxLength: number): string => {
   // remove all non-allowed characters and buffering whitespace
-  let sanitized = input.replace(/[^a-zA-Z0-9 \-.!?]/g, '').trim();
+  let sanitized = input.replace(/[^a-zA-Z0-9_ \-.!?]/g, '').trim();
 
   // collapse more than one consecutive space into a single space
   sanitized = sanitized.replace(/  +/g, ' ');


### PR DESCRIPTION
## Goal

allow underscores when sanitizing text.

- enum values require underscores. currently the code changes enum values, e.g. `ARTICLE_QUALITY` becomes `ARTICLEQUALITY`.
