### PR TITLE
feat: prep scheduledSource field in graph

### DIFF
--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -644,6 +644,10 @@ input CreateApprovedCorpusItemInput {
   """
   scheduledSurfaceGuid: ID
   """
+  Optionally, specify the source of the Scheduled Item. Could be one of: MANUAL or ML
+  """
+  scheduledSource: ScheduledItemSource
+  """
   A comma-separated list of reasons for manually adding an item (only supplied when `source` is MANUAL).
   """
   manualAdditionReasons: String


### PR DESCRIPTION
## Goal

prep `scheduledSource` field in graph for `createApprovedCorpsuItem` mutation

- unblocks lambda implementation of the related mutation
- follow up PR to implement resolving of new field: https://github.com/Pocket/content-monorepo/pull/79 