### PR TITLE
fix: lambda size issue

### DIFF
--- a/.circleci/shared.yml
+++ b/.circleci/shared.yml
@@ -542,13 +542,14 @@ jobs:
             pnpm --config.shamefully-hoist=true --config.hoist=true --config.node-linker=true --config.symlinks=false --config.shared-workspace-lockfile=false deploy --filter=<< parameters.scope >> --prod pruned
       - run:
           name: Package Lambda
+          # zip -y argument preserves symlinks, which helps stay within the 250 MB unzipped .zip size limit for Lambdas.
           command: |
             cd ~/bug/project/pruned
             cp -r package.json dist/
             cp -r node_modules/ dist/node_modules/
 
             cd dist
-            zip -r9 ~/project/${CIRCLE_SHA1}.zip .
+            zip -r9y ~/project/${CIRCLE_SHA1}.zip .
             mkdir /tmp/artifacts
             cp ~/project/${CIRCLE_SHA1}.zip /tmp/artifacts/
             cd ..


### PR DESCRIPTION
## Goal
Fix an [error in CircleCI](https://app.circleci.com/pipelines/github/Pocket/content-monorepo/592/workflows/37d10d21-2f91-48b5-897c-ebc4a32f3a16/jobs/8081) that happens when we add dependencies to the corpus-scheduler-lambda:

> An error occurred (InvalidParameterValueException) when calling the UpdateFunctionCode operation: Unzipped size must be smaller than 262144000 bytes

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-799