### PR TITLE
fix: corpus scheduler retries failed SQS records

### DIFF
--- a/lambdas/corpus-scheduler-lambda/src/index.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/index.spec.ts
@@ -104,24 +104,23 @@ describe('corpus scheduler lambda', () => {
 
   it('returns batch item failure if curated-corpus-api has error, with partial success', async () => {
     mockGetUrlMetadata();
-    // Note: msw uses handlers in reverse order, so 2nd request will error, and 1st will succeed.
     mockCreateApprovedCorpusItemOnce({ errors: [{ message: 'server bork' }] });
-    mockCreateApprovedCorpusItemOnce();
 
     const fakeEvent = {
-      Records: [
-        { messageId: '1', body: JSON.stringify(record) },
-        { messageId: '2', body: JSON.stringify(record) },
-      ],
+      Records: [{ messageId: '1', body: JSON.stringify(record) }],
     } as unknown as SQSEvent;
 
-    const actual = await processor(
-      fakeEvent,
-      null as unknown as Context,
-      null as unknown as Callback,
+    await expect(
+      processor(
+        fakeEvent,
+        null as unknown as Context,
+        null as unknown as Callback,
+      ),
+    ).rejects.toThrow(
+      new Error(
+        'processSQSMessages failed: Error: createApprovedCorpusItem mutation failed: server bork',
+      ),
     );
-
-    expect(actual).toEqual({ batchItemFailures: [{ itemIdentifier: '2' }] });
   }, 7000);
 
   it('returns batch item failure if curated-corpus-api returns null data', async () => {
@@ -132,13 +131,13 @@ describe('corpus scheduler lambda', () => {
       Records: [{ messageId: '1', body: JSON.stringify(record) }],
     } as unknown as SQSEvent;
 
-    const actual = await processor(
-      fakeEvent,
-      null as unknown as Context,
-      null as unknown as Callback,
-    );
-
-    expect(actual).toEqual({ batchItemFailures: [{ itemIdentifier: '1' }] });
+    await expect(
+      processor(
+        fakeEvent,
+        null as unknown as Context,
+        null as unknown as Callback,
+      ),
+    ).rejects.toThrow(Error);
   }, 7000);
 
   it('returns no batch item failures if curated-corpus-api request is successful', async () => {
@@ -149,12 +148,10 @@ describe('corpus scheduler lambda', () => {
       Records: [{ messageId: '1', body: JSON.stringify(record) }],
     } as unknown as SQSEvent;
 
-    const actual = await processor(
+    await processor(
       fakeEvent,
       null as unknown as Context,
       null as unknown as Callback,
     );
-
-    expect(actual).toEqual({ batchItemFailures: [] });
   });
 });

--- a/lambdas/corpus-scheduler-lambda/src/index.ts
+++ b/lambdas/corpus-scheduler-lambda/src/index.ts
@@ -1,9 +1,4 @@
-import {
-  SQSEvent,
-  SQSHandler,
-  SQSBatchItemFailure,
-  SQSBatchResponse,
-} from 'aws-lambda';
+import { SQSEvent, SQSHandler } from 'aws-lambda';
 import * as Sentry from '@sentry/serverless';
 import config from './config';
 import { processAndScheduleCandidate } from './utils';
@@ -20,28 +15,14 @@ console.log('corpus scheduler lambda');
 
 /**
  * @param event data from an SQS message - should be an array of items to create / schedule in corpus
- * @returns SQSBatchResponse (all failed records)
+ * @exception Error Raises an exception on error, which causes the batch to be retried.
+ *  Lambda batchSize is 1 to avoid retrying successfully processed records.
  */
-export const processor: SQSHandler = async (
-  event: SQSEvent,
-): Promise<SQSBatchResponse> => {
-  // prevents successful records showing up in the queue if there were some failed records
-  // https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
-  const failedItems: SQSBatchItemFailure[] = [];
-
+export const processor: SQSHandler = async (event: SQSEvent) => {
+  // We have set batchSize to 1, so the follow for loop is expected to have 1 iteration.
   for await (const record of event.Records) {
-    try {
-      await processAndScheduleCandidate(record);
-    } catch (error) {
-      console.warn(`Unable to process message -> Reason: ${error}`);
-      Sentry.captureException(error);
-      Sentry.addBreadcrumb({
-        message: `Unable to process message -> Reason: ${error}`,
-      });
-      failedItems.push({ itemIdentifier: record.messageId });
-    }
+    await processAndScheduleCandidate(record);
   }
-  return { batchItemFailures: failedItems };
 };
 
 // the actual function has to be wrapped in order for sentry to work


### PR DESCRIPTION
## Goal
[MC-808](https://mozilla-hub.atlassian.net/browse/MC-808) When Corpus Scheduler fails, it should eventually insert records in a deadletter queue if they can't be processed.

When a schedule failed to be processed on March 11th it was not retried, because [ReportBatchItemFailures](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting) is not enabled on the SQS source.

![Screenshot from 2024-03-11 12-26-02](https://github.com/Pocket/content-monorepo/assets/1547251/52c96b75-0f51-4021-bd71-15f587b86a39)

## Implementation Decisions
Terraform-Modules doesn't allow for `ReportBatchItemFailures` to be enabled. I don't think it's worth the effort of making a change in Terraform-Modules because we don't need batch processing.

## References

- JIRA ticket: [MC-808](https://mozilla-hub.atlassian.net/browse/MC-808)
- [CloudWatch log 2024-03-11](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FCorpusSchedulerLambda-Dev-SQS-Function/log-events/2024$252F03$252F11$252F$255B38$255D64ca097d4ab046349a871d8675db3fd5)

[MC-808]: https://mozilla-hub.atlassian.net/browse/MC-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MC-808]: https://mozilla-hub.atlassian.net/browse/MC-808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ