### PR TITLE
Add new DE RSS prospect feed

### DIFF
--- a/packages/prospectapi-common/types.ts
+++ b/packages/prospectapi-common/types.ts
@@ -99,6 +99,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.DOMAIN_ALLOWLIST,
       ProspectType.DISMISSED,
       ProspectType.TITLE_URL_MODELED,
+      ProspectType.RSS_LOGISTIC,
     ],
   },
   {

--- a/servers/curated-corpus-api/src/shared/types.ts
+++ b/servers/curated-corpus-api/src/shared/types.ts
@@ -57,6 +57,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.DOMAIN_ALLOWLIST,
       ProspectType.DISMISSED,
       ProspectType.TITLE_URL_MODELED,
+      ProspectType.RSS_LOGISTIC,
     ],
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_DEDE,
   },


### PR DESCRIPTION
## Goal

As part of the ML DE Scheduler work, we are adding a new RSS prospecting feed for the German market. It will behave similar to the US RSS Logistic.

This is piggy-backing on Jonathan's MC-719 PR but can be adjusted as needed. 

## References

JIRA ticket:

https://mozilla-hub.atlassian.net/browse/MC-849


Documentation:

[- Project doc](https://mozilla-hub.atlassian.net/wiki/spaces/MozSocial/pages/552108152/German+DE+Scheduler+Project#3-%2F-New-Prospecting-Feed-in-Admin-Tool)
