### PR TITLE
Revert "fix(deps): update prisma monorepo to v5 (major)"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,7 +328,7 @@ importers:
         version: 3.529.1(@aws-sdk/client-s3@3.529.1)
       '@devoxa/prisma-relay-cursor-connection':
         specifier: 3.1.0
-        version: 3.1.0(@prisma/client@5.11.0)
+        version: 3.1.0(@prisma/client@4.16.2)
       '@pocket-tools/apollo-utils':
         specifier: 3.3.4
         version: 3.3.4
@@ -336,8 +336,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(@babel/core@7.24.0)(@types/node@20.11.13)(typescript@5.3.3)
       '@prisma/client':
-        specifier: ^5.0.0
-        version: 5.11.0(prisma@5.11.0)
+        specifier: ^4.16.2
+        version: 4.16.2(prisma@4.16.2)
       '@sentry/node':
         specifier: 7.49.0
         version: 7.49.0
@@ -409,8 +409,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       prisma:
-        specifier: ^5.0.0
-        version: 5.11.0
+        specifier: ^4.16.1
+        version: 4.16.2
       supertest:
         specifier: 6.3.4
         version: 6.3.4
@@ -2370,12 +2370,12 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@devoxa/prisma-relay-cursor-connection@3.1.0(@prisma/client@5.11.0):
+  /@devoxa/prisma-relay-cursor-connection@3.1.0(@prisma/client@4.16.2):
     resolution: {integrity: sha512-JI+YJ35lenTbB2oO3YzdeSoAFThtJXMHFdJ0mrrVlJefGfycby3LR1sXV1qKgY4fL4wcGy6+Bz+tXC5zz50Ojw==}
     peerDependencies:
       '@prisma/client': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
-      '@prisma/client': 5.11.0(prisma@5.11.0)
+      '@prisma/client': 4.16.2(prisma@4.16.2)
       graphql-fields: 2.0.3
     dev: false
 
@@ -3468,9 +3468,9 @@ packages:
       typescript: 5.3.3
     dev: false
 
-  /@prisma/client@5.11.0(prisma@5.11.0):
-    resolution: {integrity: sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==}
-    engines: {node: '>=16.13'}
+  /@prisma/client@4.16.2(prisma@4.16.2):
+    resolution: {integrity: sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==}
+    engines: {node: '>=14.17'}
     requiresBuild: true
     peerDependencies:
       prisma: '*'
@@ -3478,35 +3478,17 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: 5.11.0
+      '@prisma/engines-version': 4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81
+      prisma: 4.16.2
     dev: false
 
-  /@prisma/debug@5.11.0:
-    resolution: {integrity: sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==}
+  /@prisma/engines-version@4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81:
+    resolution: {integrity: sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg==}
+    dev: false
 
-  /@prisma/engines-version@5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102:
-    resolution: {integrity: sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==}
-
-  /@prisma/engines@5.11.0:
-    resolution: {integrity: sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==}
+  /@prisma/engines@4.16.2:
+    resolution: {integrity: sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==}
     requiresBuild: true
-    dependencies:
-      '@prisma/debug': 5.11.0
-      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
-      '@prisma/fetch-engine': 5.11.0
-      '@prisma/get-platform': 5.11.0
-
-  /@prisma/fetch-engine@5.11.0:
-    resolution: {integrity: sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==}
-    dependencies:
-      '@prisma/debug': 5.11.0
-      '@prisma/engines-version': 5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102
-      '@prisma/get-platform': 5.11.0
-
-  /@prisma/get-platform@5.11.0:
-    resolution: {integrity: sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==}
-    dependencies:
-      '@prisma/debug': 5.11.0
 
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -11615,13 +11597,13 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
-  /prisma@5.11.0:
-    resolution: {integrity: sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==}
-    engines: {node: '>=16.13'}
+  /prisma@4.16.2:
+    resolution: {integrity: sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==}
+    engines: {node: '>=14.17'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.11.0
+      '@prisma/engines': 4.16.2
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}

--- a/servers/curated-corpus-api/package.json
+++ b/servers/curated-corpus-api/package.json
@@ -34,7 +34,7 @@
     "@devoxa/prisma-relay-cursor-connection": "3.1.0",
     "@pocket-tools/apollo-utils": "3.3.4",
     "@pocket-tools/ts-logger": "^1.3.0",
-    "@prisma/client": "^5.0.0",
+    "@prisma/client": "^4.16.2",
     "@sentry/node": "7.49.0",
     "@sentry/tracing": "7.49.0",
     "@snowplow/node-tracker": "3.5.0",
@@ -60,7 +60,7 @@
     "jest": "29.7.0",
     "nock": "13.5.1",
     "nodemon": "3.0.1",
-    "prisma": "^5.0.0",
+    "prisma": "^4.16.1",
     "supertest": "6.3.4",
     "ts-jest": "29.1.2",
     "tsconfig": "workspace:*"


### PR DESCRIPTION
Reverts Pocket/content-monorepo#116

Suspected culprit in Sentry errors: https://pocket.sentry.io/issues/4383422265/?project=5938284&query=is%3Aunresolved&referrer=issue-stream&stream_index=0