### PR TITLE
refactor: deprecate manually scheduled snowplow fields

### DIFF
--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -908,11 +908,11 @@ input CreateScheduledCorpusItemInput {
   """
   A comma-separated list of reasons for manually scheduling an item. Helps ML improve models for sets of scheduled items.
   """
-  manualScheduleReasons: String
+  reasons: String
   """
   Free-text entered by the curator to give further detail to the manual schedule reason(s) provided.
   """
-  manualScheduleReasonComment: String
+  reasonComment: String
 }
 
 """

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem.integration.ts
@@ -110,9 +110,8 @@ describe('mutations: ScheduledItem', () => {
         scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
         source: ScheduledItemSource.MANUAL,
-        manualScheduleReasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
-        manualScheduleReasonComment:
-          'i scheduled this because i thought it would be nice',
+        reasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
+        reasonComment: 'i scheduled this because i thought it would be nice',
       };
 
       const result = await request(app)
@@ -171,9 +170,8 @@ describe('mutations: ScheduledItem', () => {
         scheduledSurfaceGuid: existingScheduledEntry.scheduledSurfaceGuid,
         scheduledDate,
         source: ScheduledItemSource.MANUAL,
-        manualScheduleReasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
-        manualScheduleReasonComment:
-          'i scheduled this because i thought it would be nice',
+        reasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
+        reasonComment: 'i scheduled this because i thought it would be nice',
       };
 
       const result = await request(app)
@@ -211,9 +209,8 @@ describe('mutations: ScheduledItem', () => {
         scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
         source: ScheduledItemSource.MANUAL,
-        manualScheduleReasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
-        manualScheduleReasonComment:
-          'i scheduled this because i thought it would be nice',
+        reasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
+        reasonComment: 'i scheduled this because i thought it would be nice',
       };
 
       const result = await request(app)
@@ -305,9 +302,8 @@ describe('mutations: ScheduledItem', () => {
         scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
         source: ScheduledItemSource.MANUAL,
-        manualScheduleReasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
-        manualScheduleReasonComment:
-          'i scheduled this because i thought it would be nice',
+        reasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
+        reasonComment: 'i scheduled this because i thought it would be nice',
       };
 
       const result = await request(app)
@@ -343,9 +339,8 @@ describe('mutations: ScheduledItem', () => {
         scheduledSurfaceGuid: 'NEW_TAB_EN_US',
         scheduledDate: '2100-01-01',
         source: ScheduledItemSource.MANUAL,
-        manualScheduleReasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
-        manualScheduleReasonComment:
-          'i scheduled this because i thought it would be nice',
+        reasons: `${ManualScheduleReason.EVERGREEN},${ManualScheduleReason.PUBLISHER_DIVERSITY}`,
+        reasonComment: 'i scheduled this because i thought it would be nice',
       };
 
       const result = await request(app)

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -78,7 +78,7 @@ export default {
       reviewedCorpusItem:
         'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-8',
       scheduledCorpusItem:
-        'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-6',
+        'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-7',
     },
   },
 };

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -114,8 +114,8 @@ export type DeleteScheduledItemInput = {
 
 // type to map to the input coming from the graph mutation
 export type CreateScheduledItemGraphInput = CreateScheduledItemInput & {
-  manualScheduleReasons?: string;
-  manualScheduleReasonComment?: string;
+  reasons?: string;
+  reasonComment?: string;
 };
 
 export type RescheduleScheduledItemInput = {

--- a/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
@@ -17,7 +17,6 @@ import { tracker } from './tracker';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
 import { getUnixTimestamp } from '../../shared/utils';
 import {
-  ManualScheduleReason,
   ScheduledCorpusItemStatus,
   ScheduledItemSource,
 } from '../../shared/types';
@@ -193,99 +192,6 @@ describe('ScheduledItemSnowplowHandler', () => {
           data: {
             ...scheduledItemEventContextData,
             generated_by: CorpusItemSource.ML,
-          },
-        },
-      ]);
-    });
-  });
-  describe('manual schedule reasons', () => {
-    it('should send a single manual schedule reason with no comment', async () => {
-      const scheduledItemWithMlData: ScheduledCorpusItemPayload = {
-        scheduledCorpusItem: {
-          ...scheduledCorpusItem,
-          generated_by: ScheduledItemSource.ML,
-          status: ScheduledCorpusItemStatus.ADDED,
-          reasons: ['TOPIC', 'PUBLISHER'],
-          reasonComment: 'why did i rescheudle this? see above',
-          manualScheduleReasons: [`${ManualScheduleReason.EVERGREEN}`],
-        },
-      };
-
-      emitter.emit(ScheduledCorpusItemEventType.ADD_SCHEDULE, {
-        ...scheduledItemWithMlData,
-        eventType: ScheduledCorpusItemEventType.ADD_SCHEDULE,
-      });
-
-      // make sure we only have good events
-      const allEvents = await waitForSnowplowEvents();
-      expect(allEvents.total).toEqual(1);
-      expect(allEvents.good).toEqual(1);
-      expect(allEvents.bad).toEqual(0);
-
-      const goodEvents = await getGoodSnowplowEvents();
-
-      const eventContext = parseSnowplowData(
-        goodEvents[0].rawEvent.parameters.cx,
-      );
-
-      expect(eventContext.data).toMatchObject([
-        {
-          schema: config.snowplow.schemas.scheduledCorpusItem,
-          data: {
-            ...scheduledItemEventContextData,
-            status: 'added',
-            generated_by: CorpusItemSource.ML,
-            manually_scheduled_reasons: [ManualScheduleReason.EVERGREEN],
-          },
-        },
-      ]);
-    });
-
-    it('should send a multiple manual schedule reasons with a comment', async () => {
-      const scheduledItemWithMlData: ScheduledCorpusItemPayload = {
-        scheduledCorpusItem: {
-          ...scheduledCorpusItem,
-          generated_by: ScheduledItemSource.ML,
-          status: ScheduledCorpusItemStatus.ADDED,
-          reasons: ['TOPIC', 'PUBLISHER'],
-          reasonComment: 'why did i rescheudle this? see above',
-          manualScheduleReasons: [
-            ManualScheduleReason.EVERGREEN,
-            ManualScheduleReason.TOPIC_DIVERSITY,
-          ],
-          manualScheduleReasonsComment: 'i scheduled this manually!',
-        },
-      };
-
-      emitter.emit(ScheduledCorpusItemEventType.ADD_SCHEDULE, {
-        ...scheduledItemWithMlData,
-        eventType: ScheduledCorpusItemEventType.ADD_SCHEDULE,
-      });
-
-      // make sure we only have good events
-      const allEvents = await waitForSnowplowEvents();
-      expect(allEvents.total).toEqual(1);
-      expect(allEvents.good).toEqual(1);
-      expect(allEvents.bad).toEqual(0);
-
-      const goodEvents = await getGoodSnowplowEvents();
-
-      const eventContext = parseSnowplowData(
-        goodEvents[0].rawEvent.parameters.cx,
-      );
-
-      expect(eventContext.data).toMatchObject([
-        {
-          schema: config.snowplow.schemas.scheduledCorpusItem,
-          data: {
-            ...scheduledItemEventContextData,
-            status: 'added',
-            generated_by: CorpusItemSource.ML,
-            manually_scheduled_reasons: [
-              ManualScheduleReason.EVERGREEN,
-              ManualScheduleReason.TOPIC_DIVERSITY,
-            ],
-            manually_scheduled_reason_comment: 'i scheduled this manually!',
           },
         },
       ]);

--- a/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.ts
@@ -94,9 +94,6 @@ export class ScheduledItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
         updated_by: item.updatedBy ?? undefined,
         status_reasons: item.reasons ?? undefined,
         status_reason_comment: item.reasonComment ?? undefined,
-        manually_scheduled_reasons: item.manualScheduleReasons ?? undefined,
-        manually_scheduled_reason_comment:
-          item.manualScheduleReasonsComment ?? undefined,
         generated_by: item.generated_by ?? undefined,
         status: item.status ?? undefined,
       },

--- a/servers/curated-corpus-api/src/events/snowplow/schema.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/schema.ts
@@ -209,14 +209,6 @@ export type ScheduledCorpusItem = {
    */
   status_reason_comment?: string;
   /**
-   * The list of reasons a curator scheduled the item manually.
-   */
-  manually_scheduled_reasons?: string[];
-  /**
-   *  An optional comment added by the curator when scheduling an item manually.
-   */
-  manually_scheduled_reason_comment?: string;
-  /**
    * The method by which this item was generated. Possible values include ML and MANUAL.
    */
   generated_by?: ScheduledItemSource;

--- a/servers/curated-corpus-api/src/events/types.ts
+++ b/servers/curated-corpus-api/src/events/types.ts
@@ -53,14 +53,10 @@ export type ScheduledCorpusItemPayload = {
   scheduledCorpusItem: ScheduledItem & {
     // the method by which this item was generated (MANUAL or ML, for a scheduled item)
     generated_by?: ScheduledItemSource;
-    // for some surfaces, curators will provide at least one reason and
-    // optionally a comment when manually scheduling a corpus item.
-    // the purpose here is for ML to know *why* items are manually scheduled
-    // in an effort to improve their modeling.
-    manualScheduleReasons?: string[];
-    manualScheduleReasonsComment?: string;
-    // will only be present when unscheduling an item from a limited set of
-    // surfaces. these inform ML of why an item was unscheduled.
+    // multi-purpose field intended to capture the reason(s) for taking the
+    // action. currently, this is only when either scheduling or unscheduling.
+    // specifically, only when scheduling and unscheduling directly from the
+    // schedule view in the admin tool.
     reasons?: string[];
     reasonComment?: string;
     // the status of the scheduled_corpus_item, as decided by a curator.


### PR DESCRIPTION
## Goal

refactor: deprecate manually scheduled snowplow fields

- move to pre-existing reasons fields

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-884

Snowplow PR:

- https://github.com/Pocket/spec/pull/221