### PR TITLE
feat(search): adding in skeleton for corpus search

### DIFF
--- a/servers/curated-corpus-api/jest.setup.js
+++ b/servers/curated-corpus-api/jest.setup.js
@@ -4,5 +4,5 @@ process.env.AWS_ENDPOINT = process.env.AWS_ENDPOINT || 'http://localhost:4566';
 jest.setTimeout(8000);
 // https://github.com/facebook/react-native/issues/35701#issuecomment-1847579429
 Object.defineProperty(global, 'performance', {
-    writable: true,
+  writable: true,
 });

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -1,20 +1,6 @@
 scalar Upload
 
 """
-The outcome of the curators reviewing a prospective story.
-"""
-enum CuratedStatus {
-  """
-  Recommend this story for Pocket users. This is first-tier content.
-  """
-  RECOMMENDATION
-  """
-  This story is suitable for our curated corpus. It's a second-tier recommendation.
-  """
-  CORPUS
-}
-
-"""
 Options for returning items sorted by the supplied field.
 """
 enum OrderBy {

--- a/servers/curated-corpus-api/schema-public.graphql
+++ b/servers/curated-corpus-api/schema-public.graphql
@@ -126,12 +126,91 @@ This is a future improvement, not needed now.
 """
 union Surface = ScheduledSurface
 
+"""
+An edge in a connection.
+"""
+type CorpusItemEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+  """
+  The Corpus Item at the end of the edge.
+  """
+  node: CorpusItem!
+}
+
+"""
+The connection type for Corpus Item.
+"""
+type CorpusItemConnection {
+  """
+  A list of edges.
+  """
+  edges: [CorpusItemEdge!]!
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  Identifies the total count of Corpus Items in the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+Available fields for filtering Corpus Items.
+"""
+input CorpusItemFilter {
+  """
+  Optional filter on the URL field. Returns partial matches.
+  """
+  url: Url
+  """
+  Optional filter on the title field. Returns partial matches.
+  """
+  title: String
+  """
+  Optional filter on the excerpt field. Returns partial matches.
+  """
+  excerpt: String
+  """
+  Optional filter on the publisher field. Returns partial matches.
+  """
+  publisher: String
+  """
+  Optional filter on the authors field. Returns partial matches.
+  """
+  author: String
+  """
+  Optional filter on the topic field.
+  """
+  topic: String
+  """
+  Optional filter on the status of Approved Items.
+  """
+  status: CuratedStatus
+  """
+  Optional filter on the language Corpus Items have been classified as.
+  This is a two-letter string, e.g. 'EN' for English or 'DE' for 'German'.
+  """
+  language: CorpusLanguage
+}
+
 type Query {
-    scheduledSurface(id: ID!): ScheduledSurface!
-    """
-    This is a future improvement, not needed now.
-    """
-    surface(id: ID!): Surface!
+  scheduledSurface(id: ID!): ScheduledSurface!
+  """
+  This is a future improvement, not needed now.
+  """
+  surface(id: ID!): Surface!
+
+  """
+  Retrieves a paginated, filterable list of Corpus Items.
+  """
+  corpusItems(
+    filters: CorpusItemFilter
+    pagination: PaginationInput
+  ): CorpusItemConnection!
 }
 
 type SavedItem @key(fields: "url") {

--- a/servers/curated-corpus-api/schema-shared.graphql
+++ b/servers/curated-corpus-api/schema-shared.graphql
@@ -11,6 +11,20 @@ extend schema
     )
 
 """
+The outcome of the curators reviewing a prospective story.
+"""
+enum CuratedStatus {
+  """
+  Recommend this story for Pocket users. This is first-tier content.
+  """
+  RECOMMENDATION
+  """
+  This story is suitable for our curated corpus. It's a second-tier recommendation.
+  """
+  CORPUS
+}
+
+"""
 A URL - usually, for an interesting story on the internet that's worth saving to Pocket.
 """
 scalar Url

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -25,6 +25,7 @@ export default {
     defaultMaxAge: 86400,
     pagination: {
       approvedItemsPerPage: 30,
+      curatedItemsPerPage: 30,
       rejectedItemsPerPage: 30,
       maxAllowedResults: 100,
       scheduledSurfaceHistory: 10,

--- a/servers/curated-corpus-api/src/database/queries/CorpusItem.ts
+++ b/servers/curated-corpus-api/src/database/queries/CorpusItem.ts
@@ -1,0 +1,145 @@
+// need this to be able to use Prisma-native types for orderBy and filter clauses
+import * as prisma from '.prisma/client';
+import {
+  ApprovedItem as PrismaApprovedItem,
+  PrismaClient,
+} from '.prisma/client';
+import {
+  Connection,
+  findManyCursorConnection,
+} from '@devoxa/prisma-relay-cursor-connection';
+import {
+  ApprovedItem,
+  CorpusItem,
+  CorpusItemFilter,
+  PaginationInput,
+} from '../types';
+import { getCorpusItemFromApprovedItem } from '../../shared/utils';
+
+/**
+ * A dedicated type for the unique cursor value used in the getCorpusItems query.
+ * Essential to get findManyCursorConnection to work as expected.
+ */
+type CorpusItemCursor = {
+    externalId: string;
+  };
+
+/**
+ * Return a Relay-style paginated, optionally filtered list of approved items.
+ *
+ * @param db
+ * @param pagination
+ * @param filters
+ */
+export async function getCorpusItems(
+  db: PrismaClient,
+  pagination: PaginationInput,
+  filters: CorpusItemFilter,
+): Promise<Connection<CorpusItem>> {
+  // Set up the SQL clauses with our defaults (orderBy) and any filters supplied
+  // by the client.
+  const baseArgs: prisma.Prisma.ApprovedItemFindManyArgs = {
+    orderBy: { createdAt: 'desc' },
+    where: constructWhereClauseFromFilters(filters),
+    include: {
+      authors: {
+        orderBy: [{ sortOrder: 'asc' }],
+      },
+    },
+  };
+
+  // Unleash the full potential of the below function that extends Prisma's own `findMany`.
+  //
+  // This helper function returns a list of ApprovedItem edges alongside a `totalCount` value
+  // and a `pageInfo` object (see type above in the promise returned: `Connection<ApprovedItem>`)
+  // that matches what the GraphQL server expects to provide to the client perfectly.
+  //
+  // Step 1: Provide at least two types - ApprovedItem as the record/entity we're using, and
+  // ApprovedItemCursor defined at the top of this file to specify a custom field for the cursor.
+  return findManyCursorConnection<
+    // this is the type returned by Step 2 below - it must be a native Prisma type
+    PrismaApprovedItem,
+    CorpusItemCursor,
+    // this is the type we need to conform to for each node to satisfy the graphql
+    // schema (which uses our custom ApprovedItem type (that contains authors))
+    // (afaict - the docs aren't great)
+    CorpusItem,
+    // this is the return structure of this function
+    // (afaict - the docs aren't great)
+    {
+      cursor: string;
+      node: CorpusItem;
+    }
+  >(
+    // Step 2: the function will generate cursor/take/skip arguments for us in `args`,
+    // need to add our own to that.
+    (args) => {
+      return db.approvedItem.findMany({
+        ...args,
+        ...baseArgs,
+      });
+    },
+    () => db.approvedItem.count({ where: baseArgs.where }),
+    // Step 3: Pass the PaginationInput here exactly as it arrives all the way from
+    // the query - the types are 100% compatible.
+    pagination,
+    // Step 4: Provide additional options.
+    {
+      // Option 1: The default cursor is the `id` field of the record.
+      // We don't expose the numeric ID of each Approved Item. Use `externalId`
+      // instead, which is also a unique field.
+      getCursor: (record) => ({
+        externalId: record.externalId,
+      }),
+      // Option 2: Callback function that encodes the cursor before returning
+      // the response object to the resolver function and then on to the client.
+      encodeCursor: (cursor) =>
+        Buffer.from(JSON.stringify(cursor)).toString('base64'),
+      // Option 3: Callback function that decodes the cursor that may be passed in
+      // as part of `pagination` variables (either `before` or `after`) before
+      // sending it along as the now-decoded `externalId` value to Prisma.
+      decodeCursor: (cursor) =>
+        JSON.parse(Buffer.from(cursor, 'base64').toString('ascii')),
+      // to conform to the custom, non-prisma type, we need to explicitly define
+      // the structure of each node.
+      recordToEdge: (record) => {
+        return {
+          // typescript is making this more difficult than it needs to be. authors
+          // is returned based on `baseArgs` above, but because this property isn't
+          // in the prisma ApprovedItem type, we have to cast the variable as our
+          // custom ApprovedItem type (which *does* contain authors data).
+          node: getCorpusItemFromApprovedItem(record as ApprovedItem),
+        };
+      },
+    },
+  );
+}
+
+/**
+ * Convert the GraphQL filter for approved items into a 'where' clause
+ * that Prisma expects to receive.
+ *
+ * @param filters
+ */
+const constructWhereClauseFromFilters = (
+  filters: CorpusItemFilter,
+): prisma.Prisma.ApprovedItemWhereInput => {
+  // Get out quickly if no filters have been provided.
+  if (!filters) return {};
+
+  return {
+    // Exact filters for language, curation status and topic
+    language: filters.language ? { equals: filters.language } : undefined,
+    status: filters.status ? { equals: filters.status } : undefined,
+    topic: filters.topic ? { equals: filters.topic } : undefined,
+
+    // Substring match for title and URL
+    title: filters.title ? { contains: filters.title } : undefined,
+    url: filters.url ? { contains: filters.url } : undefined,
+    excerpt: filters.excerpt ? { contains: filters.excerpt } : undefined,
+    publisher: filters.publisher ? { contains: filters.publisher } : undefined,
+    authors: filters.author
+      ? { some: { name: { contains: filters.author } } }
+      : undefined,
+  };
+};

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -55,6 +55,17 @@ export type ApprovedItemFilter = {
   url?: string;
 };
 
+export type CorpusItemFilter = {
+  language?: string;
+  status?: CuratedStatus;
+  title?: string;
+  topic?: string;
+  url?: string;
+  excerpt?: string;
+  publisher?: string;
+  author?: string;
+};
+
 export type RejectedCuratedCorpusItemFilter = {
   url?: string;
   title?: string;

--- a/servers/curated-corpus-api/src/public/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/index.ts
@@ -1,7 +1,11 @@
 import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
-import { getCorpusItem, getSavedCorpusItem } from './queries/CorpusItem';
+import {
+  corpusItems,
+  getCorpusItem,
+  getSavedCorpusItem,
+} from './queries/CorpusItem';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -21,5 +25,7 @@ export const resolvers = {
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).
     scheduledSurface: getScheduledSurface,
+    // Public query to search the corpus
+    corpusItems: corpusItems,
   },
 };

--- a/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.ts
@@ -3,8 +3,12 @@ import {
   getApprovedItemByExternalId,
   getApprovedItemByUrl,
 } from '../../../database/queries/ApprovedItem';
-import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
+import { getCorpusItems } from '../../../database/queries/CorpusItem';
 
+import { getCorpusItemFromApprovedItem } from '../../../shared/utils';
+import { IPublicContext } from '../../context';
+import { Connection } from '@devoxa/prisma-relay-cursor-connection';
+import config from '../../../config';
 /**
  * Pulls in approved corpus items for a given id or url.
  *
@@ -26,7 +30,7 @@ export async function getCorpusItem({ id, url }, { db }): Promise<CorpusItem> {
 export async function getSavedCorpusItem(
   item,
   args,
-  { db }
+  { db },
 ): Promise<CorpusItem> {
   const { url } = item;
 
@@ -36,4 +40,39 @@ export async function getSavedCorpusItem(
   }
 
   return getCorpusItemFromApprovedItem(approvedItem);
+}
+
+/**
+ * This query retrieves curated items from the database.
+ *
+ * @param parent
+ * @param args
+ * @param context
+ */
+export async function corpusItems(
+  parent,
+  args,
+  context: IPublicContext,
+): Promise<Connection<CorpusItem>> {
+  let { pagination } = args;
+
+  // Set the defaults for pagination if nothing's been provided
+  if (
+    !pagination ||
+    (pagination.first === undefined && pagination.last === undefined)
+  ) {
+    pagination = { first: config.app.pagination.curatedItemsPerPage };
+  } else {
+    // Add some limits to how many items can be retrieved at any one time.
+    // These limits are higher than the defaults applied above.
+    const maxAllowedResults = config.app.pagination.maxAllowedResults;
+    if (pagination.first && pagination.first > maxAllowedResults) {
+      pagination.first = maxAllowedResults;
+    }
+    if (pagination.last && pagination.last > maxAllowedResults) {
+      pagination.last = maxAllowedResults;
+    }
+  }
+
+  return await getCorpusItems(context.db, pagination, args.filters);
 }

--- a/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
@@ -85,3 +85,41 @@ export const CORPUS_ITEM_TARGET_REFERENCE_RESOLVER = gql`
     }
   }
 `;
+
+export const CORPUS_ITEMS = gql`
+  query corpusItems($filters: CorpusItemFilter, $pagination: PaginationInput) {
+    corpusItems(filters: $filters, pagination: $pagination) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          id
+          title
+          authors {
+            name
+          }
+          publisher
+          datePublished
+          excerpt
+          topic
+          target {
+            __typename
+            ... on Collection {
+              slug
+            }
+
+            ... on SyndicatedArticle {
+              slug
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/servers/curated-corpus-api/src/test/helpers/createApprovedItemHelper.ts
+++ b/servers/curated-corpus-api/src/test/helpers/createApprovedItemHelper.ts
@@ -40,16 +40,24 @@ export type CreateApprovedItemHelperInput =
  */
 export async function createApprovedItemHelper(
   prisma: PrismaClient,
-  data: CreateApprovedItemHelperInput
+  data: CreateApprovedItemHelperInput,
+  authors?: string[],
 ): Promise<ApprovedItem> {
   const random = Math.round(Math.random() * 1000);
 
-  // randomize number of authors
-  const authorCount = faker.number.int({ min: 1, max: 3 });
-  const authors: ApprovedItemAuthor[] = [];
+  let authorData: ApprovedItemAuthor[] = [];
 
-  for (let i = 0; i < authorCount; i++) {
-    authors.push({ name: faker.person.fullName(), sortOrder: i });
+  if (authors) {
+    authorData = authors.map((name: string, index: number) => {
+      return { name, sortOrder: index } as ApprovedItemAuthor;
+    });
+  } else {
+    // randomize number of authors
+    const authorCount = faker.number.int({ min: 1, max: 3 });
+
+    for (let i = 0; i < authorCount; i++) {
+      authorData.push({ name: faker.person.fullName(), sortOrder: i });
+    }
   }
 
   // defaults for optional properties
@@ -61,7 +69,7 @@ export async function createApprovedItemHelper(
     url: `${faker.internet.url()}/${faker.lorem.slug()}/${faker.string.uuid()}`,
     excerpt: faker.lorem.sentence(15),
     authors: {
-      create: authors,
+      create: authorData,
     },
     status: faker.helpers.arrayElement([
       CuratedStatus.RECOMMENDATION,


### PR DESCRIPTION
## Goal

Pocket would like to experiment with providing value direct from the corpus with various search capablities.


This is a stop gap until we have a search DB up on our end where we will subscribe to corpus event bridge events.

