### PR TITLE
fix: revert prospect API translation lambda sentry version

### DIFF
--- a/lambdas/prospect-api-translation-lambda/package.json
+++ b/lambdas/prospect-api-translation-lambda/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.529.1",
     "@aws-sdk/lib-dynamodb": "3.529.1",
-    "@sentry/serverless": "7.95.0",
+    "@sentry/serverless": "6.19.7",
     "content-common": "workspace:*",
     "prospectapi-common": "workspace:*",
     "uuid": "9.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ importers:
         specifier: 3.529.1
         version: 3.529.1(@aws-sdk/client-dynamodb@3.529.1)
       '@sentry/serverless':
-        specifier: 7.95.0
-        version: 7.95.0
+        specifier: 6.19.7
+        version: 6.19.7
       content-common:
         specifier: workspace:*
         version: link:../../packages/content-common
@@ -3909,6 +3909,17 @@ packages:
       '@sentry/utils': 7.95.0
     dev: false
 
+  /@sentry/core@6.19.7:
+    resolution: {integrity: sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/hub': 6.19.7
+      '@sentry/minimal': 6.19.7
+      '@sentry/types': 6.19.7
+      '@sentry/utils': 6.19.7
+      tslib: 1.14.1
+    dev: false
+
   /@sentry/core@7.101.1:
     resolution: {integrity: sha512-XSmXXeYT1d4O14eDF3OXPJFUgaN2qYEeIGUztqPX9nBs9/ij8y/kZOayFqlIMnfGvjOUM+63sy/2xDBOpFn6ug==}
     engines: {node: '>=8'}
@@ -3940,6 +3951,40 @@ packages:
     dependencies:
       '@sentry/types': 7.95.0
       '@sentry/utils': 7.95.0
+    dev: false
+
+  /@sentry/hub@6.19.7:
+    resolution: {integrity: sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/types': 6.19.7
+      '@sentry/utils': 6.19.7
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/minimal@6.19.7:
+    resolution: {integrity: sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/hub': 6.19.7
+      '@sentry/types': 6.19.7
+      tslib: 1.14.1
+    dev: false
+
+  /@sentry/node@6.19.7:
+    resolution: {integrity: sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/core': 6.19.7
+      '@sentry/hub': 6.19.7
+      '@sentry/types': 6.19.7
+      '@sentry/utils': 6.19.7
+      cookie: 0.4.2
+      https-proxy-agent: 5.0.1
+      lru_map: 0.3.3
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@sentry/node@7.101.1:
@@ -3988,6 +4033,22 @@ packages:
       '@sentry/utils': 7.95.0
     dev: false
 
+  /@sentry/serverless@6.19.7:
+    resolution: {integrity: sha512-uGOfoh3DH+fvUu7LhMLlnd4sAPdBfzFnfQNHnfw8jF/6tC53wdEDH/bBS9d+g8OC37ixJ+jrZIV1lHF5ann37w==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@sentry/minimal': 6.19.7
+      '@sentry/node': 6.19.7
+      '@sentry/tracing': 6.19.7
+      '@sentry/types': 6.19.7
+      '@sentry/utils': 6.19.7
+      '@types/aws-lambda': 8.10.134
+      '@types/express': 4.17.21
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@sentry/serverless@7.95.0:
     resolution: {integrity: sha512-mdccJjGlBLTqYmNIuTWDlWiyak0gwaOFqICJgj7nl0ELjglEDumdrUG6/jpjz8uV1EF1lTIvjBLy0VRB+mmRdQ==}
     engines: {node: '>=10'}
@@ -4000,11 +4061,27 @@ packages:
       '@types/express': 4.17.21
     dev: false
 
+  /@sentry/tracing@6.19.7:
+    resolution: {integrity: sha512-ol4TupNnv9Zd+bZei7B6Ygnr9N3Gp1PUrNI761QSlHtPC25xXC5ssSD3GMhBgyQrcvpuRcCFHVNNM97tN5cZiA==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/hub': 6.19.7
+      '@sentry/minimal': 6.19.7
+      '@sentry/types': 6.19.7
+      '@sentry/utils': 6.19.7
+      tslib: 1.14.1
+    dev: false
+
   /@sentry/tracing@7.62.0:
     resolution: {integrity: sha512-3QuThslt43m6Ui4AVAVCjlfQYeRhlRJJpFDrQd60WfRWXEeTr00VSRmIDfPUKmBFBDiXK+xXjTb/uMUM3ZeDOg==}
     engines: {node: '>=8'}
     dependencies:
       '@sentry-internal/tracing': 7.62.0
+    dev: false
+
+  /@sentry/types@6.19.7:
+    resolution: {integrity: sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==}
+    engines: {node: '>=6'}
     dev: false
 
   /@sentry/types@7.101.1:
@@ -4025,6 +4102,14 @@ packages:
   /@sentry/types@7.95.0:
     resolution: {integrity: sha512-ouU7NsEcrwmcnXHMNBGmKZEmKMzmgPGoBydZn1gukCI67Ci71fAYpPNrbtmjai6+jtsY21o45rVLqExru2sdfw==}
     engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@6.19.7:
+    resolution: {integrity: sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==}
+    engines: {node: '>=6'}
+    dependencies:
+      '@sentry/types': 6.19.7
+      tslib: 1.14.1
     dev: false
 
   /@sentry/utils@7.101.1:
@@ -7087,7 +7172,7 @@ packages:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.5.0-dev.20240329
+      typescript: 5.5.0-dev.20240402
     dev: false
 
   /drange@1.1.1:
@@ -13368,8 +13453,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.5.0-dev.20240329:
-    resolution: {integrity: sha512-T1vHxyzRt1MeCLzQdY8JYOM1K9XRs4YgTOzMjlw8m5K19P9264rc22CyvUB9lA0vBIcMSDjObfh+/GVHMOXhkg==}
+  /typescript@5.5.0-dev.20240402:
+    resolution: {integrity: sha512-Dg6kiTZGVvuj9hqDzrqqUwZ3ruAcF1E7e9tSM53pP1XvZhPd4ZHLBF2rdbzjT2wIJOYL9Vl8OkAcL7dCJBB4Fg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false


### PR DESCRIPTION
## Goal

revert prospect API translation lambda sentry version

- the update to 7.95.0 broke, but may be due to packager/pnpm
- reverting here to unblock, will investigate on dev