### PR TITLE
feat: [MC-924] remove importApprovedCorpusItem mutation

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/index.ts
@@ -11,7 +11,6 @@ import { getRejectedItems } from './queries/RejectedItem';
 import { getScheduledItems } from './queries/ScheduledItem';
 import {
   createApprovedItem,
-  importApprovedItem,
   rejectApprovedItem,
   updateApprovedItem,
   updateApprovedItemAuthors,
@@ -102,6 +101,5 @@ export const resolvers = {
     deleteScheduledCorpusItem: deleteScheduledItem,
     rescheduleScheduledCorpusItem: rescheduleScheduledItem,
     uploadApprovedCorpusItemImage: uploadApprovedItemImage,
-    importApprovedCorpusItem: importApprovedItem,
   },
 };

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -90,19 +90,3 @@ export const UPLOAD_APPROVED_ITEM_IMAGE = gql`
     }
   }
 `;
-
-export const IMPORT_APPROVED_ITEM = gql`
-  mutation importApprovedItem($data: ImportApprovedCorpusItemInput!) {
-    importApprovedCorpusItem(data: $data) {
-      approvedItem {
-        ...CuratedItemData
-      }
-      scheduledItem {
-        ...ScheduledItemData
-        scheduledSurfaceGuid
-      }
-    }
-  }
-  ${CuratedItemData}
-  ${ScheduledItemData}
-`;

--- a/servers/curated-corpus-api/src/admin/resolvers/types.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/types.ts
@@ -1,42 +1,10 @@
-import { ScheduledItem } from '.prisma/client';
-import { ApprovedItem } from '../../database/types';
 import {
   ActionScreen,
   ApprovedItemAuthor,
-  CorpusItemSource,
   CorpusLanguage,
   CreateScheduledItemInput,
   CuratedStatus,
-  ScheduledItemSource,
 } from 'content-common';
-
-// this is the type returned from the importApprovedItem mutation
-export type ImportApprovedCorpusItemPayload = {
-  approvedItem: ApprovedItem;
-  scheduledItem: ScheduledItem;
-};
-
-// this maps to the ImportApprovedCorpusItemInput graph input
-export type ImportApprovedCorpusItemApiInput = {
-  url: string;
-  title: string;
-  excerpt: string;
-  status: CuratedStatus;
-  language: string;
-  publisher: string;
-  imageUrl: string;
-  topic?: string;
-  source: CorpusItemSource;
-  isCollection: boolean;
-  isSyndicated: boolean;
-  createdAt: number;
-  createdBy: string;
-  updatedAt: number;
-  updatedBy: string;
-  scheduledDate: string;
-  scheduledSurfaceGuid: string;
-  scheduledSource: ScheduledItemSource;
-};
 
 // this maps to the UpdateApprovedCorpusItemInput graph input
 export type UpdateApprovedCorpusItemApiInput = {

--- a/servers/curated-corpus-api/src/database/mutations/ApprovedItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/ApprovedItem.ts
@@ -2,7 +2,6 @@ import { PrismaClient } from '.prisma/client';
 import {
   ApprovedItem,
   CreateApprovedItemInput,
-  ImportApprovedItemInput,
   UpdateApprovedItemAuthorsInput,
   UpdateApprovedItemInput,
 } from '../types';
@@ -35,28 +34,6 @@ export async function createApprovedItem(
         create: data.authors,
       },
     },
-    include: {
-      authors: {
-        orderBy: [{ sortOrder: 'asc' }],
-      },
-    },
-  });
-}
-
-/**
- * This mutation imports/creates an approved curated item.
- * Due to the nature of the import, we do not throw an
- * error when an approved item already exists
- *
- * @param db
- * @param data
- */
-export async function importApprovedItem(
-  db: PrismaClient,
-  data: ImportApprovedItemInput,
-): Promise<ApprovedItem> {
-  return db.approvedItem.create({
-    data,
     include: {
       authors: {
         orderBy: [{ sortOrder: 'asc' }],

--- a/servers/curated-corpus-api/src/database/mutations/ScheduledItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/ScheduledItem.ts
@@ -4,7 +4,6 @@ import { CreateScheduledItemInput } from 'content-common';
 
 import {
   DeleteScheduledItemInput,
-  ImportScheduledItemInput,
   RescheduleScheduledItemInput,
   ScheduledItem,
 } from '../types';
@@ -47,29 +46,6 @@ export async function createScheduledItem(
       createdBy: username,
       source,
     },
-    include: {
-      approvedItem: {
-        include: {
-          authors: {
-            orderBy: [{ sortOrder: 'asc' }],
-          },
-        },
-      },
-    },
-  });
-}
-
-/**
- * Create (import) a scheduled item for a given approved item
- * @param db
- * @param data
- */
-export async function importScheduledItem(
-  db: PrismaClient,
-  data: ImportScheduledItemInput,
-): Promise<ScheduledItem> {
-  return db.scheduledItem.create({
-    data,
     include: {
       approvedItem: {
         include: {

--- a/servers/curated-corpus-api/src/database/mutations/index.ts
+++ b/servers/curated-corpus-api/src/database/mutations/index.ts
@@ -3,12 +3,10 @@ export {
   deleteApprovedItem,
   updateApprovedItem,
   updateApprovedItemAuthors,
-  importApprovedItem,
 } from './ApprovedItem';
 export { createRejectedItem } from './RejectedItem';
 export {
   createScheduledItem,
   deleteScheduledItem,
   rescheduleScheduledItem,
-  importScheduledItem,
 } from './ScheduledItem';

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -29,35 +29,6 @@ export type CreateApprovedItemInput = {
   isSyndicated: boolean;
 };
 
-export type ImportApprovedItemInput = {
-  url: string;
-  title: string;
-  excerpt: string;
-  status: CuratedStatus;
-  language: string;
-  publisher: string;
-  imageUrl: string;
-  topic: string;
-  source: CorpusItemSource;
-  isCollection: boolean;
-  isSyndicated: boolean;
-  createdAt: Date;
-  createdBy: string;
-  updatedAt: Date;
-  updatedBy: string;
-};
-
-export type ImportScheduledItemInput = {
-  approvedItemId: number;
-  scheduledSurfaceGuid: string;
-  scheduledDate: string;
-  source: ScheduledItemSource;
-  createdAt: Date;
-  createdBy: string;
-  updatedAt: Date;
-  updatedBy: string;
-};
-
 export type PaginationInput = {
   after?: string;
   before?: string;


### PR DESCRIPTION
## Goal
Remove unused mutation `importApprovedCorpusItem` to reduce maintenance. For MC-899 we need to store domain names to display a warning when the domain name is new. Without `importApprovedCorpusItem` there's one less mutation we need to change.

## I'd love feedback/perspectives on:

Is there a good reason to continue to support this mutation? I checked that it has [not been used in the last 3 months](https://studio.apollographql.com/graph/pocket-admin-api/variant/current/insights?fastModeRange=lastThreeMonths&insightsTab=operations&operationSearch=importApprovedCorpusItem&operationsPage=0&range=lastThreeMonths).

I believe the original use-case for this mutation was for the [curation-migration-backfill](https://github.com/Pocket/curation-tools-data-sync/tree/main/curation-migration-backfill) to migrate records from MySQL to curated-corpus-api in 2022.