### PR TITLE
chore: add more fields to reschedule snowplow event

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem/index.ts
@@ -303,6 +303,8 @@ export async function rescheduleScheduledItem(
           scheduledCorpusItem: {
             ...rescheduledItem,
             action_screen: actionScreen,
+            generated_by: rescheduleData.source,
+            status: ScheduledCorpusItemStatus.RESCHEDULED,
             original_scheduled_corpus_item_external_id: deletedItem.externalId,
           },
         },

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem/rescheduleScheduledItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ScheduledItem/rescheduleScheduledItem.integration.ts
@@ -19,6 +19,7 @@ import { ScheduledCorpusItemEventType } from '../../../../events/types';
 import {
   ACCESS_DENIED_ERROR,
   MozillaAccessGroup,
+  ScheduledCorpusItemStatus,
 } from '../../../../shared/types';
 import { startServer } from '../../../../express';
 import { IAdminContext } from '../../../context';
@@ -283,6 +284,14 @@ describe('mutations: ScheduledItem (rescheduleScheduledCorpusItem)', () => {
     // 3- Event has the right values
     expect(rescheduleEventCall.scheduledCorpusItem.action_screen).toEqual(
       ActionScreen.SCHEDULE,
+    );
+
+    expect(rescheduleEventCall.scheduledCorpusItem.generated_by).toEqual(
+      ScheduledItemSource.MANUAL,
+    );
+
+    expect(rescheduleEventCall.scheduledCorpusItem.status).toEqual(
+      ScheduledCorpusItemStatus.RESCHEDULED,
     );
 
     // a new externalId should have been generated


### PR DESCRIPTION
## Goal

add more fields to reschedule snowplow event

- add generated_by and status

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-981