### PR TITLE
fix(scheduler lambda): [MC-1027] Scheduler lambda times out and generates errors

### DIFF
--- a/infrastructure/corpus-scheduler-lambda/src/corpusSchedulerLambda.ts
+++ b/infrastructure/corpus-scheduler-lambda/src/corpusSchedulerLambda.ts
@@ -35,14 +35,15 @@ export class CorpusSchedulerSQSLambda extends Construct {
         lambda: {
           runtime: LAMBDA_RUNTIMES.NODEJS20,
           handler: 'index.handler',
-          timeout: 120,
+          timeout: 360,
           memorySizeInMb: 512,
           reservedConcurrencyLimit: 1,
           environment: {
             REGION: this.vpc.region,
             SENTRY_DSN: this.getSentryDsn(),
             ALLOWED_TO_SCHEDULE: this.getAllowedToSchedule(),
-            ENABLE_SCHEDULED_DATE_VALIDATION: this.getEnableScheduledDateValidation(),
+            ENABLE_SCHEDULED_DATE_VALIDATION:
+              this.getEnableScheduledDateValidation(),
             GIT_SHA: this.getGitSha(),
             JWT_KEY: `${config.name}/${config.environment}/JWT_KEY`,
             ENVIRONMENT:
@@ -94,17 +95,25 @@ export class CorpusSchedulerSQSLambda extends Construct {
   }
 
   private getAllowedToSchedule() {
-    const allowedToSchedule = new DataAwsSsmParameter(this, 'allowed-to-schedule', {
-      name: `/${config.name}/${config.environment}/ALLOWED_TO_SCHEDULE`,
-    });
+    const allowedToSchedule = new DataAwsSsmParameter(
+      this,
+      'allowed-to-schedule',
+      {
+        name: `/${config.name}/${config.environment}/ALLOWED_TO_SCHEDULE`,
+      },
+    );
 
     return allowedToSchedule.value;
   }
 
   private getEnableScheduledDateValidation() {
-    const enableScheduledDateValidation = new DataAwsSsmParameter(this, 'enable-scheduled-date-validation', {
-      name: `/${config.name}/${config.environment}/ENABLE_SCHEDULED_DATE_VALIDATION`,
-    });
+    const enableScheduledDateValidation = new DataAwsSsmParameter(
+      this,
+      'enable-scheduled-date-validation',
+      {
+        name: `/${config.name}/${config.environment}/ENABLE_SCHEDULED_DATE_VALIDATION`,
+      },
+    );
 
     return enableScheduledDateValidation.value;
   }


### PR DESCRIPTION
## Goal

Fix Sentry errors linked in the JIRA ticket!

- Increased timeout from 2 minutes to 6 minutes for the Corpus Scheduler lambda.

- Recent runs show it times out at the 2 minute point and runs for about a minute during the second run to finish the job. Doubling the recent average time to add a margin of safety.

🍐 with @mmiermans 

Ref: https://mozilla-hub.atlassian.net/browse/MC-1027
