### PR TITLE
chore: update Collection.integration test to check that a CollectionStory relates to a Parser Item

### DIFF
--- a/servers/collection-api/src/public/resolvers/queries/Collection.integration.ts
+++ b/servers/collection-api/src/public/resolvers/queries/Collection.integration.ts
@@ -138,6 +138,7 @@ describe('public queries: Collection', () => {
           curationCategory.name,
         );
         expect(collections[i].stories[0].authors).not.to.be.empty;
+        expect(collections[i].stories[0].item.givenUrl).not.to.be.null;
         expect(collections[i].IABParentCategory.name).to.equal(
           IABParentCategory.name,
         );
@@ -853,6 +854,7 @@ describe('public queries: Collection', () => {
       expect(collection.title).to.equal('ultra suede is a miracle');
       expect(collection.authors.length).to.equal(1);
       expect(collection.stories.length).to.be.greaterThan(0);
+      expect(collection.stories[0].item.givenUrl).not.to.be.null;
       expect(collection.curationCategory.name).to.equal(curationCategory.name);
       expect(collection.stories[0].authors).not.to.be.empty;
       expect(collection.IABParentCategory.name).to.equal(

--- a/servers/collection-api/src/shared/fragments.gql.ts
+++ b/servers/collection-api/src/shared/fragments.gql.ts
@@ -72,6 +72,9 @@ export const CollectionStoryData = gql`
     authors {
       ...CollectionStoryAuthorData
     }
+    item {
+      givenUrl
+    }
     publisher
     sortOrder
     fromPartner


### PR DESCRIPTION
## Goal
Update public `Collection.integration.ts` to ensure that a `CollectionStory` resolves a Parser `Item`. This is a remediation for the [Collection API May 13 incident](https://mozilla-hub.atlassian.net/wiki/spaces/MozSocial/pages/734461953/Collections+missing+text+article+links+13+May+2024).

## References

JIRA ticket:

- [https://mozilla-hub.atlassian.net/browse/MC-1091](https://mozilla-hub.atlassian.net/browse/MC-1091
)