### PR TITLE
feat(corpus): additional fields on approved item events

### DIFF
--- a/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
@@ -17,25 +17,25 @@ export const eventBusConfig: EventHandlerCallbackMap = {
   [ScheduledCorpusItemEventType.ADD_SCHEDULE]: (data: any) => {
     return payloadBuilders.scheduledItemEvent(
       config.eventBridge.addScheduledItemEventType,
-      data
+      data,
     );
   },
   [ScheduledCorpusItemEventType.REMOVE_SCHEDULE]: (data: any) => {
     return payloadBuilders.scheduledItemEvent(
       config.eventBridge.removeScheduledItemEventType,
-      data
+      data,
     );
   },
   [ScheduledCorpusItemEventType.RESCHEDULE]: (data: any) => {
     return payloadBuilders.scheduledItemEvent(
       config.eventBridge.updateScheduledItemEventType,
-      data
+      data,
     );
   },
   [ReviewedCorpusItemEventType.UPDATE_ITEM]: (data: any) => {
     return payloadBuilders.approvedItemEvent(
       config.eventBridge.updateApprovedItemEventType,
-      data
+      data,
     );
   },
 };
@@ -53,7 +53,7 @@ const payloadBuilders = {
    */
   scheduledItemEvent(
     eventType: string,
-    data: ScheduledCorpusItemPayload
+    data: ScheduledCorpusItemPayload,
   ): ScheduledItemEventBusPayload {
     return {
       eventType: eventType,
@@ -82,7 +82,7 @@ const payloadBuilders = {
   },
   approvedItemEvent(
     eventType: string,
-    data: ReviewedCorpusItemPayload
+    data: ReviewedCorpusItemPayload,
   ): ApprovedItemEventBusPayload {
     // The nullish coalesce and checking for properties are due to
     // union type in ReviewedCorpusItemPayload
@@ -104,12 +104,13 @@ const payloadBuilders = {
         'updatedAt' in item
           ? item.updatedAt.toUTCString()
           : new Date().toUTCString(),
-      // 2022-06-21: authors are included as an array of objects matching the
-      // ApprovedItemAuthor type definition in /src/database/types.ts
-      // as of this writing, this data is not expected by event bridge and
-      // will be discarded. it is added now only for potential future use
-      // by clients consuming from event bridge.
       authors: 'authors' in item ? item.authors : undefined,
+      isCollection: 'isCollection' in item ? item.isCollection : undefined,
+      domainName: 'domainName' in item ? item.domainName : undefined,
+      datePublished:
+        'datePublished' in item ? item.datePublished?.toUTCString() : undefined,
+      isTimeSensitive:
+        'isTimeSensitive' in item ? item.isTimeSensitive : undefined,
     };
   },
 };

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
@@ -110,6 +110,10 @@ describe('EventBusHandler', () => {
         updatedAt: new Date(1648225373000).toUTCString(),
         eventType: config.eventBridge.updateApprovedItemEventType,
         authors: scheduledCorpusItem.approvedItem.authors,
+        isCollection: false,
+        isTimeSensitive: false,
+        datePublished: undefined,
+        domainName: 'test.com',
       };
       emitter.emit(ReviewedCorpusItemEventType.UPDATE_ITEM, {
         reviewedCorpusItem: scheduledCorpusItem.approvedItem,

--- a/servers/curated-corpus-api/src/events/types.ts
+++ b/servers/curated-corpus-api/src/events/types.ts
@@ -106,9 +106,13 @@ export type ApprovedItemEventBusPayload = BaseEventBusPayload &
       | 'isSyndicated'
       | 'createdBy'
       | 'authors'
+      | 'isCollection'
+      | 'domainName'
+      | 'isTimeSensitive'
     >
   > & {
     approvedItemExternalId: string; // externalId of ApprovedItem
     createdAt?: string; // UTC timestamp string
     updatedAt: string; // UTC timestamp string;
+    datePublished?: string; // UTC timestamp string;
   };


### PR DESCRIPTION
## Goal
Include fields already on the object in events, to provide richer data to downstream services:
isCollection, isTimeSensitive, datePublished, domainName

_Does not change snowplow event schema_. This additive change just adds optional fields to EventBridge events. Downstream consumers can choose whether to use the data or not (authors field is prior art).