### PR TITLE
feat(corpus): emit 'add-approved-item' events to bus

### DIFF
--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -56,6 +56,7 @@ export default {
     removeScheduledItemEventType: 'remove-scheduled-item',
     updateScheduledItemEventType: 'update-scheduled-item',
     updateApprovedItemEventType: 'update-approved-item',
+    addApprovedItemEventType: 'add-approved-item',
     source: 'curation-migration-datasync',
   },
   sentry: {

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
@@ -38,6 +38,12 @@ export const eventBusConfig: EventHandlerCallbackMap = {
       data,
     );
   },
+  [ReviewedCorpusItemEventType.ADD_ITEM]: (data: any) => {
+    return payloadBuilders.approvedItemEvent(
+      config.eventBridge.addApprovedItemEventType,
+      data,
+    );
+  },
 };
 
 // To add a new event handler, create a function that generates the

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
@@ -94,6 +94,54 @@ describe('EventBusHandler', () => {
     expect(fake).toHaveBeenCalledTimes(2);
   });
   describe('approved item events', () => {
+    it('add-approved-item should send event with proper data', async () => {
+      const expectedEvent: ApprovedItemEventBusPayload = {
+        approvedItemExternalId: '123-abc',
+        url: 'https://test.com/a-story',
+        title: 'Everything you need to know about React',
+        excerpt: 'Something here',
+        publisher: 'Octopus Publishing House',
+        imageUrl: 'https://test.com/image.png',
+        language: 'EN',
+        topic: 'EDUCATION',
+        isSyndicated: false,
+        createdAt: new Date(1648225373000).toUTCString(),
+        createdBy: 'Amy',
+        updatedAt: new Date(1648225373000).toUTCString(),
+        eventType: config.eventBridge.addApprovedItemEventType,
+        authors: scheduledCorpusItem.approvedItem.authors,
+        isCollection: false,
+        isTimeSensitive: false,
+        datePublished: undefined,
+        domainName: 'test.com',
+      };
+      emitter.emit(ReviewedCorpusItemEventType.ADD_ITEM, {
+        reviewedCorpusItem: scheduledCorpusItem.approvedItem,
+        eventType: ReviewedCorpusItemEventType.ADD_ITEM,
+      });
+      // Wait just a tad in case promise needs time to resolve
+      await setTimeout(100);
+      expect(sentryStub).toHaveBeenCalledTimes(0);
+      expect(serverLoggerErrorStub).toHaveBeenCalledTimes(0);
+      // Listener was registered on event
+      expect(
+        emitter.listeners(ReviewedCorpusItemEventType.ADD_ITEM).length,
+      ).toBe(1);
+      // Event was sent to Event Bus
+      expect(clientStub).toHaveBeenCalledTimes(1);
+      // Check that the payload is correct; since it's JSON, we need to decode the data
+      // otherwise it also does ordering check
+      const sendCommand = clientStub.mock.calls[0][0].input as any;
+      expect(sendCommand).toHaveProperty('Entries');
+      expect(sendCommand.Entries[0]).toMatchObject({
+        Source: config.eventBridge.source,
+        EventBusName: config.aws.eventBus.name,
+        DetailType: config.eventBridge.addApprovedItemEventType,
+      });
+      expect(JSON.parse(sendCommand.Entries[0]['Detail'])).toEqual(
+        expectedEvent,
+      );
+    });
     it('update-approved-item should send event with proper data', async () => {
       const expectedEvent: ApprovedItemEventBusPayload = {
         approvedItemExternalId: '123-abc',


### PR DESCRIPTION
## Goal

These events were sent to snowplow directly, but not the event bus. Only update events are currently sent. Add to the listeners so that the events are emitted to the bus for downstream applications to consume.


Relates to https://mozilla-hub.atlassian.net/browse/POCKET-10010
