### PR TITLE
fix(collection API): guard against null pagination inputs

### DIFF
--- a/servers/collection-api/src/public/resolvers/queries/Collection.ts
+++ b/servers/collection-api/src/public/resolvers/queries/Collection.ts
@@ -44,6 +44,13 @@ export async function getCollections(
   },
   { db },
 ): Promise<CollectionsResult> {
+  // guard against null values
+  // note: graphql will accept `null` for any optional input field, regardless
+  // of type. there may be a custom schema extension way to handle this at the
+  // graph level...
+  page = page ?? 1;
+  perPage = perPage ?? config.app.pagination.collectionsPerPage;
+
   const totalResults = await countPublishedCollections(db, filters);
   const collections = await getPublishedCollections(db, page, perPage, filters);
 


### PR DESCRIPTION
## Goal

guard against null pagination inputs on `getCollections` query. addresses [recent sentry critical error reports](https://pocket.sentry.io/alerts/rules/details/159379/?alert=1233&environment=production&notification_uuid=f2069762-28c2-43ed-a8c0-22de987d36bf&referrer=metric_alert_slack).

i verified that the `page: null` input was the source of the error. added a test for this case, as well as `perPage: null` just in case (as it would cause the same error). the fix here extends the fallback logic if the optional `page` and/or `perPage` inputs weren't supplied - which is to set `page` to `1` and `perPage` to the default config value.

## Implementation Decisions

- the fix isn't very scalable. graphql by default accepts `null` for optional inputs, which is the overall problem here. if this continues to be an issue elsewhere, we may want to look into manual schema constraints to disallow `null`.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1119