### PR TITLE
fix(collections): updating collections to emit event bridge (and snowplow) events on all mutations

### DIFF
--- a/servers/collection-api/src/admin/resolvers/mutations/Collection.integration.ts
+++ b/servers/collection-api/src/admin/resolvers/mutations/Collection.integration.ts
@@ -391,24 +391,6 @@ describe('mutations: Collection', () => {
       // assert that the event emitter function is called once
       expect(sendEventBridgeEventStub.calledOnce).to.be.true;
     });
-
-    it('should NOT send event bridge event for collection_created event when collection status is not PUBLISHED or ARCHIVED', async () => {
-      await request(app)
-        .post(graphQLUrl)
-        .set(headers)
-        .send({
-          query: print(CREATE_COLLECTION),
-          variables: {
-            data: {
-              ...minimumData,
-              status: CollectionStatus.DRAFT,
-            },
-          },
-        });
-
-      // assert that the event emitter function is not called
-      expect(sendEventBridgeEventStub.calledOnce).to.be.false;
-    });
   });
 
   describe('updateCollection', () => {
@@ -1072,30 +1054,6 @@ describe('mutations: Collection', () => {
         });
 
       expect(sendEventBridgeEventStub.calledOnce).to.be.true;
-    });
-
-    it('should NOT send event bridge event for collection_updated event when collection status is not PUBLISHED or ARCHIVED', async () => {
-      const input: UpdateCollectionInput = {
-        authorExternalId: author.externalId,
-        externalId: initial.externalId,
-        language: CollectionLanguage.EN,
-        slug: initial.slug,
-        status: CollectionStatus.DRAFT,
-        title: 'second iteration',
-        excerpt: 'once upon a time, the internet...',
-      };
-
-      await request(app)
-        .post(graphQLUrl)
-        .set(headers)
-        .send({
-          query: print(UPDATE_COLLECTION),
-          variables: {
-            data: input,
-          },
-        });
-
-      expect(sendEventBridgeEventStub.calledOnce).to.be.false;
     });
   });
 

--- a/servers/collection-api/src/database/mutations/Collection.ts
+++ b/servers/collection-api/src/database/mutations/Collection.ts
@@ -127,18 +127,11 @@ export async function createCollection(
     },
   });
 
-  // send event bridge event for collection_created event type
-  // note that we are only sending events for collections that are published or archived
-  if (
-    collection.status === CollectionStatus.PUBLISHED ||
-    collection.status === CollectionStatus.ARCHIVED
-  ) {
-    await sendEventBridgeEvent(
-      db,
-      EventBridgeEventType.COLLECTION_CREATED,
-      collection,
-    );
-  }
+  await sendEventBridgeEvent(
+    db,
+    EventBridgeEventType.COLLECTION_CREATED,
+    collection,
+  );
 
   return collection;
 }
@@ -317,17 +310,11 @@ export async function updateCollection(
   });
 
   // send event bridge event for collection_updated event type
-  // note that we are only sending events for collections that are published or archived
-  if (
-    collection.status === CollectionStatus.PUBLISHED ||
-    collection.status === CollectionStatus.ARCHIVED
-  ) {
-    await sendEventBridgeEvent(
-      db,
-      EventBridgeEventType.COLLECTION_UPDATED,
-      collection,
-    );
-  }
+  await sendEventBridgeEvent(
+    db,
+    EventBridgeEventType.COLLECTION_UPDATED,
+    collection,
+  );
 
   return collection;
 }
@@ -347,7 +334,7 @@ export async function updateCollectionImageUrl(
     throw new NotFoundError(`A collection by that ID could not be found`);
   }
 
-  return db.collection.update({
+  const collection = await db.collection.update({
     where: { externalId: data.externalId },
     data: { ...data },
     include: {
@@ -366,4 +353,12 @@ export async function updateCollectionImageUrl(
       },
     },
   });
+
+  // send event bridge event for collection_updated event type
+  await sendEventBridgeEvent(
+    db,
+    EventBridgeEventType.COLLECTION_UPDATED,
+    collection,
+  );
+  return collection;
 }

--- a/servers/collection-api/src/database/queries.ts
+++ b/servers/collection-api/src/database/queries.ts
@@ -8,6 +8,7 @@ export {
 export {
   countPublishedCollections,
   getCollection,
+  getCollectionByInternalId,
   getCollectionBySlug,
   getCollectionsBySlugs,
   getPublishedCollections,

--- a/servers/collection-api/src/database/queries/Collection.ts
+++ b/servers/collection-api/src/database/queries/Collection.ts
@@ -42,6 +42,38 @@ export async function getCollection(
 }
 
 /**
+ * this is primarily an admin query, which is why we don't return any author
+ * or story information.
+ *
+ * @param db
+ * @param externalId
+ */
+export async function getCollectionByInternalId(
+  db: PrismaClient,
+  internalId: number,
+): Promise<CollectionComplete> {
+  return await db.collection.findUnique({
+    where: { id: internalId },
+    include: {
+      authors: true,
+      curationCategory: true,
+      IABChildCategory: true,
+      IABParentCategory: true,
+      labels: true,
+      partnership: true,
+      stories: {
+        include: {
+          authors: {
+            orderBy: [{ sortOrder: 'asc' }],
+          },
+        },
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+      },
+    },
+  });
+}
+
+/**
  * this is primarily a client query, which is why we include authors and
  * stories by default.
  *

--- a/servers/collection-api/src/events/events.ts
+++ b/servers/collection-api/src/events/events.ts
@@ -38,6 +38,7 @@ import {
 } from '.prisma/client';
 
 import { getLabelById } from '../shared/resolvers/types';
+import { getCollectionByInternalId } from '../database/queries';
 
 /** Transformation functions below to map collection object's sub types to the ones in snowplow schema  */
 
@@ -243,6 +244,38 @@ export async function generateEventBridgePayload(
     eventType: eventType,
     object_version: 'new',
   };
+}
+
+/**
+ *
+ * Function called in the collection stories database mutation functions for create and update to emit to eventbridge
+ */
+export async function sendEventBridgeEventUpdateFromInternalCollectionId(
+  dbClient: PrismaClient,
+  collectionId: number,
+) {
+  Sentry.addBreadcrumb({
+    level: 'debug',
+    message: 'fetching collection for eventbridge',
+    data: { collectionId },
+  });
+  // retrieve the current record, pre-update
+  const collection = await getCollectionByInternalId(dbClient, collectionId);
+
+  if (!collection) {
+    Sentry.captureEvent({
+      message:
+        'Could not find collection to send to event bridge for an update',
+    });
+    // No-op because not being able to send an event should not be a fatal error
+    return;
+  }
+  // Send to event bridge with the data
+  await sendEventBridgeEvent(
+    dbClient,
+    EventBridgeEventType.COLLECTION_UPDATED,
+    collection,
+  );
 }
 
 /**


### PR DESCRIPTION
## Goal

Pocket will be building a Home slate based on collection data in our snowflake for Pride Month and future themed months. 

Upon building we discovered that events are not emitted when a collection has stories added or removed or other various scenarios.  The goal here is to emit events for all possible collection update scenarios.


## Implementation Decisions

- I removed the event filter that was only sending events if certain statuses were set. The downstream snowplow schema supports all available statuses and by filtering it out we were missing valid state changes like Published -> Draft in our datawarehouse

JIRA ticket:

-https://mozilla-hub.atlassian.net/browse/POCKET-10152
