### PR TITLE
feat(corpus): add grade field to approved item db model

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20240523213342_add_grade_to_approved_item/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20240523213342_add_grade_to_approved_item/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `ApprovedItem` ADD COLUMN `grade` ENUM('A', 'B', 'C') NULL;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -48,6 +48,7 @@ model ApprovedItem {
   authors         ApprovedItemAuthor[]
   scheduledItems  ScheduledItem[]
   domainName      String               @db.VarChar(255)
+  grade           ApprovedItemGrade?
 
   @@index([domainName])
 }
@@ -98,4 +99,10 @@ enum CuratedItemSource {
 enum ScheduledItemSource {
   MANUAL
   ML
+}
+
+enum ApprovedItemGrade {
+  A
+  B
+  C
 }

--- a/servers/curated-corpus-api/src/events/curatedCorpusEventEmitter.spec.ts
+++ b/servers/curated-corpus-api/src/events/curatedCorpusEventEmitter.spec.ts
@@ -35,6 +35,7 @@ describe('CuratedCorpusEventEmitter', () => {
     prospectId: 'abc-123',
     url: 'https://test.com',
     domainName: 'test.com',
+    grade: null,
     status: CuratedStatus.CORPUS,
     id: 123,
     title: 'Test title',

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
@@ -38,6 +38,7 @@ const scheduledCorpusItem: ScheduledItem = {
     prospectId: '456-dfg',
     url: 'https://test.com/a-story',
     domainName: 'test.com',
+    grade: null,
     status: CuratedStatus.RECOMMENDATION,
     title: 'Everything you need to know about React',
     excerpt: 'Something here',

--- a/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -36,6 +36,7 @@ const approvedItem: ApprovedCorpusItemPayload = {
   prospectId: '456-dfg',
   url: 'https://test.com/a-story',
   domainName: 'test.com',
+  grade: null,
   status: CuratedStatus.RECOMMENDATION,
   title: 'Everything you need to know about React',
   excerpt: 'Something here',

--- a/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
@@ -49,6 +49,7 @@ const scheduledCorpusItem: ScheduledItem = {
     prospectId: '456-dfg',
     url: 'https://test.com/a-story',
     domainName: 'test.com',
+    grade: null,
     status: CuratedStatus.RECOMMENDATION,
     title: 'Everything you need to know about React',
     excerpt: 'Something here',

--- a/servers/curated-corpus-api/src/shared/utils.spec.ts
+++ b/servers/curated-corpus-api/src/shared/utils.spec.ts
@@ -76,6 +76,7 @@ describe('shared/utils', () => {
         prospectId: 'abc-123',
         url: 'https://test.com',
         domainName: 'test.com',
+        grade: null,
         status: CuratedStatus.CORPUS,
         id: 123,
         title: 'Test title',


### PR DESCRIPTION
## Goal

add a `grade` field to the approved item database model.

- update a couple tests that now expect the property to be present (based on prisma types)

follow-up PRs coming to add this field to the graph and snowplow.

## I'd love feedback/perspectives on:

- any issues with using an enum here? a plain string didn't seem right...

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1134