### PR TITLE
fix: authors on SnowplowProspect is optional

### DIFF
--- a/lambdas/prospect-translation-lambda/src/events/snowplow.ts
+++ b/lambdas/prospect-translation-lambda/src/events/snowplow.ts
@@ -62,7 +62,7 @@ export const generateSnowplowEntity = (
         topic: prospect.topic,
         is_collection: prospect.isCollection,
         is_syndicated: prospect.isSyndicated,
-        authors: prospect.authors.split(','),
+        authors: prospect.authors?.split(','),
         publisher: prospect.publisher,
         domain: prospect.domain,
         created_at: prospect.createdAt || Math.round((Date.now() / 1000)), // date in seconds (snowplow expects integer & not number)


### PR DESCRIPTION
## Goal

Error: https://pocket.sentry.io/issues/5398322260/?alert_rule_id=15181376&alert_type=issue&environment=production&notification_uuid=d06999e0-9665-4c74-85a6-76e844c7b2e9&project=4507222652813312&referrer=slack

`authors` on `SnowplowProspect` is a string array and is optional

