### PR TITLE
feat(corpus items): add approved item grade field to the graph

### DIFF
--- a/packages/content-common/types.ts
+++ b/packages/content-common/types.ts
@@ -18,6 +18,13 @@ export enum CorpusLanguage {
   IT = 'IT',
 }
 
+// quality grade associated with approved corpus items
+export enum ApprovedItemGrade {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+}
+
 export enum Topics {
   BUSINESS = 'BUSINESS',
   CAREER = 'CAREER',
@@ -85,6 +92,7 @@ export type CreateApprovedCorpusItemApiInput = ApprovedItemRequiredInput & {
   datePublished?: string;
   // Optional value specifying which admin screen the action originated from.
   actionScreen?: ActionScreen; // non-db, analytics only
+  grade?: ApprovedItemGrade; // quality grade of the approved item
 };
 
 export type CreateScheduledItemInput = {
@@ -352,11 +360,10 @@ export enum CuratedCorpusApiErrorCodes {
 /* AP style formatting for title */
 // String of stop words. When a lowercased word is included in this string, it will be in lowercase.
 export const STOP_WORDS =
-    'a an and at but by for in nor of on or so the to up yet';
+  'a an and at but by for in nor of on or so the to up yet';
 
 // special chars separating words, used for splitting
 export const SEPARATORS = /(\s+|[-‑–—,:;!?()“”"])/;
 
 // get the stop word in STOP_WORDS str by splitting by whitespace
 export const stop = STOP_WORDS.split(' ');
-

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -271,6 +271,10 @@ type ApprovedCorpusItem @key(fields: "url") {
   """
   topic: String!
   """
+  The quality grade associated with this CorpusItem.
+  """
+  grade: ApprovedItemGrade
+  """
   The source of the corpus item.
   """
   source: CorpusItemSource!
@@ -659,9 +663,12 @@ input CreateApprovedCorpusItemInput {
   imageUrl: Url!
   """
   A topic this story best fits in.
-  Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
   """
   topic: String!
+  """
+  The quality grade associated with this CorpusItem.
+  """
+  grade: ApprovedItemGrade
   """
   The source of the corpus item.
   """
@@ -838,9 +845,12 @@ input UpdateApprovedCorpusItemInput {
   imageUrl: Url!
   """
   A topic this story best fits in.
-  Temporarily a string value that will be provided by Prospect API, possibly an enum in the future.
   """
   topic: String!
+  """
+  The quality grade associated with this CorpusItem.
+  """
+  grade: ApprovedItemGrade
   """
   A flag to ML to not recommend this item long term after it is added to the corpus.
   Example: a story covering an election, or "The best of 202x" collection.

--- a/servers/curated-corpus-api/schema-public.graphql
+++ b/servers/curated-corpus-api/schema-public.graphql
@@ -1,5 +1,5 @@
 type Image @key(fields: "url") {
-    url: Url!
+  url: Url!
 }
 
 """
@@ -7,33 +7,33 @@ A scheduled entry for an CorpusItem to appear on a Scheduled Surface.
 For example, a story that is scheduled to appear on December 31st, 2021 on the Scheduled Surface in Firefox for the US audience.
 """
 type ScheduledSurfaceItem {
-    """
-    A backend GUID that represents this scheduled run
-    """
-    id: ID!
+  """
+  A backend GUID that represents this scheduled run
+  """
+  id: ID!
 
-    """
-    Agreed on GUID that is from our shared data pocket confluence
-    """
-    surfaceId: ID!
+  """
+  Agreed on GUID that is from our shared data pocket confluence
+  """
+  surfaceId: ID!
 
-    """
-    The date the item should run at
-    """
-    scheduledDate: Date!
+  """
+  The date the item should run at
+  """
+  scheduledDate: Date!
 
-    """
-    The curated item that should run
-    """
-    corpusItem: CorpusItem!
+  """
+  The curated item that should run
+  """
+  corpusItem: CorpusItem!
 }
 
 type SyndicatedArticle @key(fields: "slug") {
-    slug: String!
+  slug: String!
 }
 
 type Collection @key(fields: "slug") {
-    slug: String!
+  slug: String!
 }
 
 """
@@ -47,77 +47,81 @@ Represents an item that is in the Corpus and its associated manually edited meta
 TODO: CorpusItem to implement PocketResource when it becomes available.
 """
 type CorpusItem @key(fields: "id") @key(fields: "url") {
-    """
-    The GUID that is stored on an approved corpus item
-    """
-    id: ID!
-    """
-    The URL of the Approved Item.
-    """
-    url: Url!
-    """
-    The title of the Approved Item.
-    """
-    title: String!
-    """
-    The excerpt of the Approved Item.
-    """
-    excerpt: String!
-    """
-    What language this item is in. This is a two-letter code, for example, 'EN' for English.
-    """
-    language: CorpusLanguage!
-    """
-    The name of the online publication that published this story.
-    """
-    publisher: String!
-    """
-    The publication date for this story.
-    """
-    datePublished: Date
-    """
-    The image URL for this item's accompanying picture.
-    """
-    imageUrl: Url!
+  """
+  The GUID that is stored on an approved corpus item
+  """
+  id: ID!
+  """
+  The URL of the Approved Item.
+  """
+  url: Url!
+  """
+  The title of the Approved Item.
+  """
+  title: String!
+  """
+  The excerpt of the Approved Item.
+  """
+  excerpt: String!
+  """
+  What language this item is in. This is a two-letter code, for example, 'EN' for English.
+  """
+  language: CorpusLanguage!
+  """
+  The name of the online publication that published this story.
+  """
+  publisher: String!
+  """
+  The publication date for this story.
+  """
+  datePublished: Date
+  """
+  The image URL for this item's accompanying picture.
+  """
+  imageUrl: Url!
 
-    """
-    The image for this item's accompanying picture.
-    """
-    image: Image!
+  """
+  The image for this item's accompanying picture.
+  """
+  image: Image!
 
-    """
-    The author names and sort orders associated with this CorpusItem.
-    """
-    authors: [CorpusItemAuthor!]!
-    """
-    The topic associated with the Approved Item.
-    """
-    topic: String
+  """
+  The author names and sort orders associated with this CorpusItem.
+  """
+  authors: [CorpusItemAuthor!]!
+  """
+  The topic associated with this CorpusItem.
+  """
+  topic: String
+  """
+  The quality grade associated with this CorpusItem.
+  """
+  grade: ApprovedItemGrade
 
-    """
-    If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
-    """
-    target: CorpusTarget
+  """
+  If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
+  """
+  target: CorpusTarget
 }
 
 """
 Represents a surface that has scheduled items by day
 """
 type ScheduledSurface {
-    """
-    Agreed on GUID that is from our shared data pocket confluence
-    """
-    id: ID!
+  """
+  Agreed on GUID that is from our shared data pocket confluence
+  """
+  id: ID!
 
-    """
-    Internal name of the surface
-    """
-    name: String!
+  """
+  Internal name of the surface
+  """
+  name: String!
 
-    """
-    Subquery to get the ScheduledSurfaceItems to display to a user for a given date
-    """
-    items(date: Date!): [ScheduledSurfaceItem!]!
+  """
+  Subquery to get the ScheduledSurfaceItems to display to a user for a given date
+  """
+  items(date: Date!): [ScheduledSurfaceItem!]!
 }
 
 """
@@ -127,25 +131,24 @@ This is a future improvement, not needed now.
 union Surface = ScheduledSurface
 
 type Query {
-    scheduledSurface(id: ID!): ScheduledSurface!
-    """
-    This is a future improvement, not needed now.
-    """
-    surface(id: ID!): Surface!
+  scheduledSurface(id: ID!): ScheduledSurface!
+  """
+  This is a future improvement, not needed now.
+  """
+  surface(id: ID!): Surface!
 }
 
 type SavedItem @key(fields: "url") {
-    """
-    key field to identify the SavedItem entity in the ListApi service
-    """
-    url: String! @external
+  """
+  key field to identify the SavedItem entity in the ListApi service
+  """
+  url: String! @external
 
-    """
-    If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
-    """
-    corpusItem: CorpusItem
+  """
+  If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
+  """
+  corpusItem: CorpusItem
 }
-
 
 # Commented out until RecsAPI implements the fields that lets us extend Recommendation
 #extend type Recommendation  @key(fields: "corpusItemId") {

--- a/servers/curated-corpus-api/schema-shared.graphql
+++ b/servers/curated-corpus-api/schema-shared.graphql
@@ -1,14 +1,8 @@
 extend schema
-    @link(
-        url: "https://specs.apollo.dev/federation/v2.0"
-        import: [
-            "@key"
-            "@shareable"
-            "@requires"
-            "@external"
-            "@inaccessible"
-        ]
-    )
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: ["@key", "@shareable", "@requires", "@external", "@inaccessible"]
+  )
 
 """
 A URL - usually, for an interesting story on the internet that's worth saving to Pocket.
@@ -27,46 +21,55 @@ scalar NonNegativeInt
 Valid language codes for curated corpus items.
 """
 enum CorpusLanguage {
-    "German"
-    DE
-    "English"
-    EN
-    "Italian"
-    IT
-    "French"
-    FR
-    "Spanish"
-    ES
+  "German"
+  DE
+  "English"
+  EN
+  "Italian"
+  IT
+  "French"
+  FR
+  "Spanish"
+  ES
+}
+
+"""
+Valid grade values for CorpusItem (public graph) and ApprovedItem (admin graph)
+"""
+enum ApprovedItemGrade {
+  A
+  B
+  C
 }
 
 """
 An author associated with a CorpusItem.
 """
 type CorpusItemAuthor {
-    name: String!
-    sortOrder: Int!
+  name: String!
+  sortOrder: Int!
 }
 
 """
 Information about pagination in a connection.
 """
 type PageInfo @shareable {
-    """
-    When paginating forwards, the cursor to continue.
-    """
-    endCursor: String
-    """
-    When paginating forwards, are there more items?
-    """
-    hasNextPage: Boolean!
-    """
-    When paginating backwards, are there more items?
-    """
-    hasPreviousPage: Boolean!
-    """
-    When paginating backwards, the cursor to continue.
-    """
-    startCursor: String
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+  """
+  When paginating backwards, are there more items?
+  """
+  hasPreviousPage: Boolean!
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
 }
 """
 Pagination request. To determine which edges to return, the connection
@@ -76,24 +79,24 @@ value for either `first` or `last`, not both). If all fields are null,
 by default will return a page with the first 30 elements.
 """
 input PaginationInput {
-    """
-    Returns the elements in the list that come after the specified cursor.
-    The specified cursor is not included in the result.
-    """
-    after: String
-    """
-    Returns the elements in the list that come before the specified cursor.
-    The specified cursor is not included in the result.
-    """
-    before: String
-    """
-    Returns the first _n_ elements from the list. Must be a non-negative integer.
-    If `first` contains a value, `last` should be null/omitted in the input.
-    """
-    first: Int
-    """
-    Returns the last _n_ elements from the list. Must be a non-negative integer.
-    If `last` contains a value, `first` should be null/omitted in the input.
-    """
-    last: Int
+  """
+  Returns the elements in the list that come after the specified cursor.
+  The specified cursor is not included in the result.
+  """
+  after: String
+  """
+  Returns the elements in the list that come before the specified cursor.
+  The specified cursor is not included in the result.
+  """
+  before: String
+  """
+  Returns the first _n_ elements from the list. Must be a non-negative integer.
+  If `first` contains a value, `last` should be null/omitted in the input.
+  """
+  first: Int
+  """
+  Returns the last _n_ elements from the list. Must be a non-negative integer.
+  If `last` contains a value, `first` should be null/omitted in the input.
+  """
+  last: Int
 }

--- a/servers/curated-corpus-api/src/admin/resolvers/types.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/types.ts
@@ -1,6 +1,7 @@
 import {
   ActionScreen,
   ApprovedItemAuthor,
+  ApprovedItemGrade,
   CorpusLanguage,
   CreateScheduledItemInput,
   CuratedStatus,
@@ -19,6 +20,7 @@ export type UpdateApprovedCorpusItemApiInput = {
   datePublished?: string;
   imageUrl: string;
   topic: string;
+  grade?: ApprovedItemGrade;
   isTimeSensitive: boolean;
   actionScreen?: ActionScreen; // non-db, analytics only
 };

--- a/servers/curated-corpus-api/src/database/mutations/ApprovedItem.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/ApprovedItem.integration.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '.prisma/client';
 
 import {
+  ApprovedItemGrade,
   CorpusItemSource,
   CorpusLanguage,
   CuratedStatus,
@@ -43,6 +44,7 @@ describe('mutations: ApprovedItem', () => {
       language: CorpusLanguage.DE,
       publisher: 'Convective Cloud',
       topic: Topics.TECHNOLOGY,
+      grade: ApprovedItemGrade.A,
       source: CorpusItemSource.PROSPECT,
       isCollection: false,
       isTimeSensitive: true,

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -1,5 +1,6 @@
 import {
   ApprovedItem as ApprovedItemModel,
+  ApprovedItemGrade,
   CuratedStatus,
   ScheduledItem as ScheduledItemModel,
 } from '.prisma/client';
@@ -23,6 +24,7 @@ export type CreateApprovedItemInput = {
   datePublished?: string;
   imageUrl: string;
   topic: string;
+  grade?: ApprovedItemGrade;
   source: CorpusItemSource;
   isCollection: boolean;
   isTimeSensitive: boolean;
@@ -131,6 +133,7 @@ export type CorpusItem = {
   imageUrl: string;
   image: Image;
   topic?: string;
+  grade?: ApprovedItemGrade;
   target?: CorpusTarget;
 };
 

--- a/servers/curated-corpus-api/src/events/curatedCorpusEventEmitter.spec.ts
+++ b/servers/curated-corpus-api/src/events/curatedCorpusEventEmitter.spec.ts
@@ -9,7 +9,7 @@ import config from '../config';
 import { getUnixTimestamp } from '../shared/utils';
 import { ApprovedItem } from '../database/types';
 import { RejectedCuratedCorpusItem } from '.prisma/client';
-import { Topics } from 'content-common';
+import { ApprovedItemGrade, Topics } from 'content-common';
 import {
   CorpusItemSource,
   CuratedStatus,
@@ -35,7 +35,7 @@ describe('CuratedCorpusEventEmitter', () => {
     prospectId: 'abc-123',
     url: 'https://test.com',
     domainName: 'test.com',
-    grade: null,
+    grade: ApprovedItemGrade.A,
     status: CuratedStatus.CORPUS,
     id: 123,
     title: 'Test title',

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusConfig.ts
@@ -72,6 +72,7 @@ const payloadBuilders = {
       publisher: data.scheduledCorpusItem.approvedItem.publisher,
       imageUrl: data.scheduledCorpusItem.approvedItem.imageUrl,
       topic: data.scheduledCorpusItem.approvedItem.topic,
+      grade: data.scheduledCorpusItem.approvedItem.grade,
       isSyndicated: data.scheduledCorpusItem.approvedItem.isSyndicated,
       createdAt: data.scheduledCorpusItem.createdAt.toUTCString(),
       createdBy: data.scheduledCorpusItem.createdBy,
@@ -84,6 +85,8 @@ const payloadBuilders = {
       // will be discarded. it is added now only for potential future use
       // by clients consuming from event bridge.
       authors: data.scheduledCorpusItem.approvedItem.authors,
+      // this is the source of the scheduled item, *not* the approved item
+      source: data.scheduledCorpusItem.source,
     };
   },
   approvedItemEvent(
@@ -91,7 +94,7 @@ const payloadBuilders = {
     data: ReviewedCorpusItemPayload,
   ): ApprovedItemEventBusPayload {
     // The nullish coalesce and checking for properties are due to
-    // union type in ReviewedCorpusItemPayload
+    // union type of ApprovedItem and RejectedItem in ReviewedCorpusItemPayload
     const item = data.reviewedCorpusItem;
     return {
       eventType: eventType,
@@ -117,6 +120,7 @@ const payloadBuilders = {
         'datePublished' in item ? item.datePublished?.toUTCString() : undefined,
       isTimeSensitive:
         'isTimeSensitive' in item ? item.isTimeSensitive : undefined,
+      source: 'source' in item ? item.source : undefined,
     };
   },
 };

--- a/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
+++ b/servers/curated-corpus-api/src/events/eventBus/EventBusHandler.spec.ts
@@ -1,7 +1,12 @@
 import { CuratedStatus } from '.prisma/client';
 import { EventBusHandler } from './EventBusHandler';
 import { CuratedCorpusEventEmitter } from '../curatedCorpusEventEmitter';
-import { CorpusItemSource, Topics, ScheduledItemSource } from 'content-common';
+import {
+  CorpusItemSource,
+  Topics,
+  ScheduledItemSource,
+  ApprovedItemGrade,
+} from 'content-common';
 import { ScheduledItem } from '../../database/types';
 import * as Sentry from '@sentry/node';
 import { EventBridgeClient } from '@aws-sdk/client-eventbridge';
@@ -38,7 +43,7 @@ const scheduledCorpusItem: ScheduledItem = {
     prospectId: '456-dfg',
     url: 'https://test.com/a-story',
     domainName: 'test.com',
-    grade: null,
+    grade: ApprovedItemGrade.A,
     status: CuratedStatus.RECOMMENDATION,
     title: 'Everything you need to know about React',
     excerpt: 'Something here',
@@ -115,6 +120,7 @@ describe('EventBusHandler', () => {
         isTimeSensitive: false,
         datePublished: undefined,
         domainName: 'test.com',
+        source: CorpusItemSource.PROSPECT,
       };
       emitter.emit(ReviewedCorpusItemEventType.ADD_ITEM, {
         reviewedCorpusItem: scheduledCorpusItem.approvedItem,
@@ -163,6 +169,7 @@ describe('EventBusHandler', () => {
         isTimeSensitive: false,
         datePublished: undefined,
         domainName: 'test.com',
+        source: CorpusItemSource.PROSPECT,
       };
       emitter.emit(ReviewedCorpusItemEventType.UPDATE_ITEM, {
         reviewedCorpusItem: scheduledCorpusItem.approvedItem,
@@ -206,6 +213,7 @@ describe('EventBusHandler', () => {
       imageUrl: 'https://test.com/image.png',
       language: 'EN',
       topic: 'EDUCATION',
+      grade: 'A',
       isSyndicated: false,
       createdAt: new Date(1648225373000).toUTCString(),
       createdBy: 'Amy',
@@ -218,6 +226,7 @@ describe('EventBusHandler', () => {
           sortOrder: 1,
         },
       ],
+      source: CorpusItemSource.MANUAL,
     };
     it.each([
       [

--- a/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -22,6 +22,7 @@ import { getUnixTimestamp } from '../../shared/utils';
 import {
   ActionScreen,
   ApprovedItemAuthor,
+  ApprovedItemGrade,
   CorpusItemSource,
   Topics,
 } from 'content-common';
@@ -36,7 +37,7 @@ const approvedItem: ApprovedCorpusItemPayload = {
   prospectId: '456-dfg',
   url: 'https://test.com/a-story',
   domainName: 'test.com',
-  grade: null,
+  grade: ApprovedItemGrade.A,
   status: CuratedStatus.RECOMMENDATION,
   title: 'Everything you need to know about React',
   excerpt: 'Something here',

--- a/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ScheduledItemSnowplowHandler.integration.ts
@@ -20,6 +20,7 @@ import { getUnixTimestamp } from '../../shared/utils';
 import { ScheduledCorpusItemStatus } from '../../shared/types';
 import {
   ActionScreen,
+  ApprovedItemGrade,
   CorpusItemSource,
   ScheduledItemSource,
   Topics,
@@ -49,7 +50,7 @@ const scheduledCorpusItem: ScheduledItem = {
     prospectId: '456-dfg',
     url: 'https://test.com/a-story',
     domainName: 'test.com',
-    grade: null,
+    grade: ApprovedItemGrade.A,
     status: CuratedStatus.RECOMMENDATION,
     title: 'Everything you need to know about React',
     excerpt: 'Something here',

--- a/servers/curated-corpus-api/src/events/types.ts
+++ b/servers/curated-corpus-api/src/events/types.ts
@@ -80,7 +80,7 @@ export interface BaseEventBusPayload {
 
 // Data for events sent to event bus for Scheduled Surface schedule
 export type ScheduledItemEventBusPayload = BaseEventBusPayload &
-  Pick<ScheduledItemModel, 'createdBy' | 'scheduledSurfaceGuid'> &
+  Pick<ScheduledItemModel, 'createdBy' | 'scheduledSurfaceGuid' | 'source'> &
   Pick<
     ApprovedItem,
     'topic' | 'isSyndicated' | keyof Omit<CorpusItem, 'id' | 'image' | 'target'>
@@ -109,6 +109,7 @@ export type ApprovedItemEventBusPayload = BaseEventBusPayload &
       | 'isCollection'
       | 'domainName'
       | 'isTimeSensitive'
+      | 'source'
     >
   > & {
     approvedItemExternalId: string; // externalId of ApprovedItem

--- a/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
@@ -35,6 +35,7 @@ export const GET_SCHEDULED_SURFACE_WITH_ITEMS = gql`
             url
           }
           topic
+          grade
         }
       }
     }

--- a/servers/curated-corpus-api/src/shared/fragments.gql.ts
+++ b/servers/curated-corpus-api/src/shared/fragments.gql.ts
@@ -17,6 +17,7 @@ export const CuratedItemData = gql`
     }
     status
     topic
+    grade
     source
     isCollection
     isTimeSensitive

--- a/servers/curated-corpus-api/src/shared/utils.spec.ts
+++ b/servers/curated-corpus-api/src/shared/utils.spec.ts
@@ -1,4 +1,9 @@
-import { CorpusItemSource, CuratedStatus, Topics } from 'content-common';
+import {
+  ApprovedItemGrade,
+  CorpusItemSource,
+  CuratedStatus,
+  Topics,
+} from 'content-common';
 
 import { MozillaAccessGroup } from 'content-common';
 import {
@@ -76,7 +81,7 @@ describe('shared/utils', () => {
         prospectId: 'abc-123',
         url: 'https://test.com',
         domainName: 'test.com',
-        grade: null,
+        grade: ApprovedItemGrade.A,
         status: CuratedStatus.CORPUS,
         id: 123,
         title: 'Test title',

--- a/servers/curated-corpus-api/src/shared/utils.ts
+++ b/servers/curated-corpus-api/src/shared/utils.ts
@@ -51,34 +51,34 @@ export function toUtcDateString(date: Date) {
 export const scheduledSurfaceAllowedValues = ScheduledSurfaces.map(
   (surface) => {
     return surface.guid;
-  }
+  },
 );
 
 // array for easy access to scheduled surface access groups
 export const scheduledSurfaceAccessGroups = ScheduledSurfaces.map(
   (surface: ScheduledSurface) => {
     return surface.accessGroup;
-  }
+  },
 );
 
 export const getScheduledSurfaceByAccessGroup = (
-  group: string
+  group: string,
 ): ScheduledSurface | undefined => {
   return ScheduledSurfaces.find(
-    (surface: ScheduledSurface) => surface.accessGroup === group
+    (surface: ScheduledSurface) => surface.accessGroup === group,
   );
 };
 
 export const getScheduledSurfaceByGuid = (
-  guid: string
+  guid: string,
 ): ScheduledSurface | undefined => {
   return ScheduledSurfaces.find(
-    (surface: ScheduledSurface) => surface.guid === guid
+    (surface: ScheduledSurface) => surface.guid === guid,
   );
 };
 
 export const getCorpusItemFromApprovedItem = (
-  approvedItem: ApprovedItem
+  approvedItem: ApprovedItem,
 ): CorpusItem => {
   const target = getPocketPath(approvedItem.url);
 
@@ -102,6 +102,7 @@ export const getCorpusItemFromApprovedItem = (
     // i wonder why typescript won't accept both. is there some deep dark
     // JS reason? or is it just better practice?
     topic: approvedItem.topic ?? undefined,
+    grade: approvedItem.grade ?? undefined,
     target: target?.key && {
       slug: target.key,
       __typename: target.type,
@@ -153,7 +154,7 @@ export const getUrlId = (path: string): string => {
  *          {locale, path} when its a pocket URL but the entities are not known.
  */
 export const getPocketPath = (
-  url: string
+  url: string,
 ): {
   locale: string;
   path: string;

--- a/servers/curated-corpus-api/src/test/helpers/createApprovedItemHelper.ts
+++ b/servers/curated-corpus-api/src/test/helpers/createApprovedItemHelper.ts
@@ -1,11 +1,14 @@
 import { Prisma, PrismaClient } from '.prisma/client';
 import { faker } from '@faker-js/faker';
-import { ApprovedItem } from '../../database/types';
+
 import {
   ApprovedItemAuthor,
+  ApprovedItemGrade,
   CorpusItemSource,
   CuratedStatus,
 } from 'content-common';
+
+import { ApprovedItem } from '../../database/types';
 import { getNormalizedDomainName } from '../../shared/utils';
 
 // the minimum of data required to create a approved curated item
@@ -24,6 +27,7 @@ interface CreateApprovedItemHelperOptionalInput {
   imageUrl?: string;
   createdBy?: string;
   topic?: string;
+  grade?: ApprovedItemGrade;
   source?: CorpusItemSource;
   isCollection?: boolean;
   isTimeSensitive?: boolean;


### PR DESCRIPTION
## Goal

add `grade` field on approved corpus items to the admin and public graphs.

- send grade and source field to event bridge
- consolidated tests a bit to only have one for all optional fields
- added a test for grade to make sure it can be unset if the admin tools sends a `null` value

## Implementation Decisions

- pretty much just following patterns

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1135