### PR TITLE
feat(snowplow): send approved corpus item grade field to snowplow

### DIFF
--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -77,7 +77,7 @@ export default {
     schemas: {
       objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-5',
       reviewedCorpusItem:
-        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-8',
+        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-9',
       scheduledCorpusItem:
         'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-8',
     },

--- a/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.integration.ts
@@ -107,6 +107,7 @@ const approvedItemEventContextData = {
   image_url: approvedItem.imageUrl,
   language: approvedItem.language,
   topic: approvedItem.topic,
+  grade: approvedItem.grade,
   is_collection: approvedItem.isCollection,
   is_time_sensitive: approvedItem.isTimeSensitive,
   is_syndicated: approvedItem.isSyndicated,

--- a/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/ReviewedItemSnowplowHandler.ts
@@ -154,6 +154,7 @@ export class ReviewedItemSnowplowHandler extends CuratedCorpusSnowplowHandler {
       updated_at: getUnixTimestamp(item.updatedAt),
       updated_by: item.updatedBy ?? undefined,
       loaded_from: item.source as CorpusItemSource,
+      grade: item.grade,
     };
 
     return context;

--- a/servers/curated-corpus-api/src/events/snowplow/schema.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/schema.ts
@@ -142,6 +142,11 @@ export type ReviewedCorpusItem = {
    * Indicates where in the Curation Tools UI the action took place. Null if the action was performed by a backend ML process.
    */
   action_screen?: ActionScreen;
+
+  /**
+   * The quality grade of the reviewed_corpus_item.
+   */
+  grade?: string;
 };
 
 /**


### PR DESCRIPTION
## Goal

send the `grade` field on approved/reviewed corpus items to snowplow.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1137