### PR TITLE
MC-1190: fix German quotes / dashes formatting

### DIFF
--- a/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
@@ -347,12 +347,12 @@ describe('utils', function () {
       const scheduledCandidate = createScheduledCandidate();
       scheduledCandidate.scheduled_corpus_item.excerpt = `Random "excerpt"`;
       scheduledCandidate.scheduled_corpus_item.language = CorpusLanguage.DE;
-      scheduledCandidate.scheduled_corpus_item.title = 'Romantic norms are in flux. No wonder - everyone’s obsessed with «polyamory».';
+      scheduledCandidate.scheduled_corpus_item.title = 'Romantic norms are in »flux«. No wonder - everyone’s obsessed with «polyamory».';
       // German quote rules should be applied
       expectedCreateApprovedCorpusItemApiOutput.excerpt = `Random „excerpt”`;
       expectedCreateApprovedCorpusItemApiOutput.language = CorpusLanguage.DE;
       // capitalization for title for German candidates shouldn't change, but German quote formatting applies
-      expectedCreateApprovedCorpusItemApiOutput.title = 'Romantic norms are in flux. No wonder — everyone’s obsessed with „polyamory”.'
+      expectedCreateApprovedCorpusItemApiOutput.title = 'Romantic norms are in „flux”. No wonder – everyone’s obsessed with „polyamory”.'
       const validateImageSpy = jest
           .spyOn(validation, 'validateImageUrl')
           .mockReturnValue(

--- a/lambdas/prospect-translation-lambda/src/lib.spec.ts
+++ b/lambdas/prospect-translation-lambda/src/lib.spec.ts
@@ -330,9 +330,9 @@ describe('lib', () => {
 
     it('should hydrate the prospect with the url meta data fields & apply German formatting to title if prospect is DE', () => {
       expected.language = 'de';
-      expected.title = 'Test-title — „Test”'; // German quotes / dash formatting expected
+      expected.title = 'Test – title-title – „Test”'; // German quotes / dash formatting expected
 
-      urlMetadata.title = 'Test-title - «Test»';
+      urlMetadata.title = 'Test - title-title - «Test»';
       urlMetadata.language = 'de';
 
       expect(expected).toEqual(
@@ -364,11 +364,11 @@ describe('lib', () => {
 
     it('should hydrate the prospect with the url meta data fields & apply excerpt German quotes/dash formatting if candidate is DE', () => {
       // German quotes / dash formatting expected
-      expected.excerpt = '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” — das musst du darüber wissen';
+      expected.excerpt = '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” – das musst du darüber wissen';
       expected.language = 'de';
       expected.title = 'test-title';
 
-      urlMetadata.excerpt = '“Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus “Tote Mädchen lügen nicht” und “Élite” – das musst du darüber wissen';
+      urlMetadata.excerpt = '«Nicht eine mehr»: Diese spanische Netflix-Serie ist ein Mix aus “Tote Mädchen lügen nicht” und »Élite« – das musst du darüber wissen';
       urlMetadata.language = 'de';
       urlMetadata.title = 'test-title';
 

--- a/packages/content-common/index.spec.ts
+++ b/packages/content-common/index.spec.ts
@@ -176,7 +176,7 @@ describe('content-common', () => {
           `“Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus “Tote Mädchen lügen nicht” und “Élite” – das musst du darüber wissen`,
       );
       expect(result).toEqual(
-          '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” — das musst du darüber wissen',
+          '„Nicht eine mehr”: Diese spanische Netflix-Serie ist ein Mix aus „Tote Mädchen lügen nicht” und „Élite” – das musst du darüber wissen',
       );
     });
     it('Replaces opening « with „', () => {
@@ -187,9 +187,13 @@ describe('content-common', () => {
       const result = formatQuotesDashesDE("Here's to the great ones!»");
       expect(result).toEqual("Here's to the great ones!”");
     });
-    it('Replaces « with „ and » with “', () => {
+    it('Replaces «Here\'s to the great ones!» with „Here\'s to the great ones!”', () => {
       const result = formatQuotesDashesDE("«Here's to the great ones!»");
       expect(result).toEqual("„Here's to the great ones!”");
+    });
+    it('Replaces »example« with „example”', () => {
+      const result = formatQuotesDashesDE("»example«");
+      expect(result).toEqual("„example”");
     });
     it('Replaces opening " with „', () => {
       const result = formatQuotesDashesDE('"Here\'s to the great ones!');
@@ -207,25 +211,25 @@ describe('content-common', () => {
       const result = formatQuotesDashesDE('“Here\'s to the great ones!"');
       expect(result).toEqual("„Here's to the great ones!”");
     });
-    it('Replaces short dash (with whitespaces) with long em dash', () => {
+    it('Replaces short dash (with whitespaces) with long en dash', () => {
       const result = formatQuotesDashesDE('"Here\'s to the great - ones!"');
-      expect(result).toEqual("„Here's to the great — ones!”");
+      expect(result).toEqual("„Here's to the great – ones!”");
     });
-    it('Replaces en dash (–) (with whitespaces) with long em dash', () => {
+    it('Replaces long em dash (–) (with whitespaces) with long en dash', () => {
       const result = formatQuotesDashesDE(
-          '"Meeresregionen – in die pelagischen Zonen – verlegt"',
+          '"Meeresregionen — in die pelagischen Zonen — verlegt"',
       );
       expect(result).toEqual(
-          '„Meeresregionen — in die pelagischen Zonen — verlegt”',
+          '„Meeresregionen – in die pelagischen Zonen – verlegt”',
       );
     });
-    it('Should not replace short dash (-) with long em dash (—) if no whitespaces in short dash', () => {
+    it('Should not replace short dash (-) with long en dash (–) if no whitespaces in short dash', () => {
       const result = formatQuotesDashesDE('"Here\'s to the great-ones!"');
       expect(result).toEqual("„Here's to the great-ones!”");
     });
-    it('Should not replace en dash (–) with long em dash (—) if no whitespaces in en dash', () => {
-      const result = formatQuotesDashesDE('"Here\'s to the great–ones!"');
-      expect(result).toEqual("„Here's to the great–ones!”");
+    it('Should not replace em dash (—) with long en dash (–) if no whitespaces in em dash', () => {
+      const result = formatQuotesDashesDE('"Here\'s to the great—ones!"');
+      expect(result).toEqual("„Here's to the great—ones!”");
     });
   });
 });

--- a/packages/content-common/index.ts
+++ b/packages/content-common/index.ts
@@ -127,12 +127,14 @@ export const formatQuotesDashesDE = (text: string): string | undefined => {
   }
   return text
       .replace(/(^|[-\u2014/([{\u2018\s])\u00AB/g, '$1\u201E') // Replaces opening « with „
+      .replace(/(^|[-\u2014/([{\u2018\s])\u00BB/g, '$1\u201E') // Replaces opening » with „
       .replace(/\u00BB/g, '\u201D') // Replaces closing » with ”
+      .replace(/\u00AB/g, '\u201D') // Replaces closing « with ”
       .replace(/(^|[-\u2014/([{\u2018\s])"/g, '$1\u201E') // Opening doubles (replaces opening " with „)
       .replace(/"/g, '\u201D') // Closing doubles (replaces closing " with ”)
       .replace(/(^|[-\u2014/([{\u2018\s])\u201c/g, '$1\u201E') // Replaces opening “ with „
-      .replace(/\s\u2013\s/g, ' \u2014 ') // Replace en dash (–) with long em dash (—)
-      .replace(/\s-\s/g, ' \u2014 '); // Replace short dash (-) with long em dash (—)
+      .replace(/\s\u2014\s/g, ' \u2013 ') // Replace em dash (—) with en dash (–)
+      .replace(/\s-\s/g, ' \u2013 '); // Replace short dash (-) with long en dash (–)
 };
 
 


### PR DESCRIPTION
## Goal

- Dashes should be changed to `en` dashes not `em` dashes. Fixed & updated tests.
- Accommodate »example« use case, should be changed to „example"

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1190