### PR TITLE
chore: disable otlp in corpus API to reduce log noise while debugging prisma

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,9 +501,6 @@ importers:
       '@pocket-tools/apollo-utils':
         specifier: 3.5.0
         version: 3.5.0
-      '@pocket-tools/tracing':
-        specifier: 1.3.15
-        version: 1.3.15
       '@pocket-tools/ts-logger':
         specifier: ^1.6.0
         version: 1.8.0
@@ -7105,7 +7102,7 @@ packages:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240723
+      typescript: 5.6.0-dev.20240726
     dev: false
 
   /drange@1.1.1:
@@ -12665,8 +12662,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.6.0-dev.20240723:
-    resolution: {integrity: sha512-IciIh6EUuMxUQ9OvnmBtrkJwuVD9zWhl9smsA+5yYz9Zpodi5qs4qhp4KldiUj86dRGREtT3+10PpUX7RMm02Q==}
+  /typescript@5.6.0-dev.20240726:
+    resolution: {integrity: sha512-/KHI7WR6NxpuU91TJcSU18tTIIzpDzu5SWQBCt2yS09dGF6Hoys85rdggtSXlHybfTZ5ZT9B2sU7DwNaoW04Pw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false

--- a/servers/curated-corpus-api/package.json
+++ b/servers/curated-corpus-api/package.json
@@ -33,7 +33,6 @@
     "@aws-sdk/lib-storage": "3.529.1",
     "@devoxa/prisma-relay-cursor-connection": "3.1.0",
     "@pocket-tools/apollo-utils": "3.5.0",
-    "@pocket-tools/tracing": "1.3.15",
     "@pocket-tools/ts-logger": "^1.6.0",
     "@prisma/client": "5.13.0",
     "@sentry/node": "7.112.2",

--- a/servers/curated-corpus-api/src/main.ts
+++ b/servers/curated-corpus-api/src/main.ts
@@ -1,27 +1,28 @@
-// nodeSDKBuilder must be the first import!!
-import {
-  nodeSDKBuilder,
-  AdditionalInstrumentation,
-} from '@pocket-tools/tracing';
-
-import config from './config';
 import { serverLogger } from '@pocket-tools/ts-logger';
 
-nodeSDKBuilder({
-  host: config.tracing.host,
-  serviceName: config.tracing.serviceName,
-  release: config.sentry.release,
-  logger: serverLogger,
-  additionalInstrumentations: [AdditionalInstrumentation.PRISMA],
-}).then(async () => {
-  // Initialize event handlers, this is outside server setup as tests
-  // mock event handling
-  initItemEventHandlers(curatedCorpusEventEmitter, [
-    corpusItemSnowplowEventHandler,
-    corpusScheduleSnowplowEventHandler,
-    eventBusHandler,
-  ]);
+import {
+  curatedCorpusEventEmitter,
+  initItemEventHandlers,
+} from './events/init';
 
+import {
+  corpusItemSnowplowEventHandler,
+  corpusScheduleSnowplowEventHandler,
+  eventBusHandler,
+} from './events/eventHandlers';
+
+import { startServer } from './express';
+import config from './config';
+
+// Initialize event handlers, this is outside server setup as tests
+// mock event handling
+initItemEventHandlers(curatedCorpusEventEmitter, [
+  corpusItemSnowplowEventHandler,
+  corpusScheduleSnowplowEventHandler,
+  eventBusHandler,
+]);
+
+async () => {
   const { adminUrl, publicUrl } = await startServer(config.app.port);
 
   serverLogger.info(
@@ -31,17 +32,4 @@ nodeSDKBuilder({
   serverLogger.info(
     `🚀 Admin server is ready at http://localhost:${config.app.port}${adminUrl}`,
   );
-});
-
-// the rest of the imports need to come *after* initializing the nodeSDKBuilder
-// above, as it monkey patches code
-import {
-  curatedCorpusEventEmitter,
-  initItemEventHandlers,
-} from './events/init';
-import {
-  corpusItemSnowplowEventHandler,
-  corpusScheduleSnowplowEventHandler,
-  eventBusHandler,
-} from './events/eventHandlers';
-import { startServer } from './express';
+};


### PR DESCRIPTION
## Goal

reduce log noise while debugging prisma connection issues. essentially falling back to [this pre-tracing version](https://github.com/Pocket/content-monorepo/commit/db4e9a23fe0c08552cce3471c177ac1e430488ab#diff-7067ab6180f2855b51db21ce1c8522cd9a5d79d64075800519b72054ef957f83) of `main.ts`.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1368