### PR TITLE
chore: increase corpus API db capacity to 64/256

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -15,8 +15,8 @@ const snowplowEndpoint = isDev
   : 'd.getpocket.com';
 
 const rds = {
-  minCapacity: isDev ? 1 : 8,
-  maxCapacity: isDev ? 1 : undefined,
+  minCapacity: isDev ? 1 : 64,
+  maxCapacity: isDev ? 1 : 256, // max allowed by AWS for Aurora Serverless V1
 };
 
 export const config = {


### PR DESCRIPTION
## Goal

increase corpus API db capacity to 64/256. related to prisma connection pool issues.

- was 8/16
- can scale back down if this is too high a bump

## Implementation Decisions

- go big for now, can scale down after monitoring for ~a week

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1370