### PR TITLE
chore: reduce logging in production for corpus API

### DIFF
--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -270,7 +270,8 @@ class CuratedCorpusAPI extends TerraformStack {
             },
             {
               name: 'LOG_LEVEL',
-              value: 'debug',
+              // do not log http, graphql, or debug events in production
+              value: config.environment === 'Prod' ? 'info' : 'debug',
             },
           ],
           logGroup: this.createCustomLogGroup('app'),


### PR DESCRIPTION
## Goal

What changed? What is the business/product goal?

- move from "debug" to "info" log level in production

### Context

the logs are currently pretty flooded with `http` level logs, almost all coming from apollo studio. this is making debugging other issues (like the ongoing prisma connection pool stuff) significantly more difficult, as there are 10-12 `http` logs per minute currently. i don't know an easy way to filter out _only_ apollo `http` events at this time. i'm not sure what `http` logs are gaining us in production right now anyway.

## I'd love feedback/perspectives on:

- are we okay removing _all_ `http` level logs in production? i think yes, but open to other opinions...

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1374