### PR TITLE
feat: add schedule review model to corpus API

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20240730195638_add_schedule_review_model/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20240730195638_add_schedule_review_model/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE `ScheduleReview` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `scheduledSurfaceGuid` VARCHAR(50) NOT NULL,
+    `scheduledDate` DATE NOT NULL,
+    `reviewedAt` DATE NOT NULL,
+    `reviewedBy` VARCHAR(255) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `ScheduleReview_scheduledSurfaceGuid_scheduledDate_key`(`scheduledSurfaceGuid`, `scheduledDate`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -84,6 +84,18 @@ model ScheduledItem {
   @@index([scheduledSurfaceGuid])
 }
 
+model ScheduleReview {
+  id                   Int        @id @default(autoincrement())
+  scheduledSurfaceGuid String     @db.VarChar(50)
+  scheduledDate        DateTime   @db.Date
+  reviewedAt           DateTime   @db.Date
+  reviewedBy           String     @db.VarChar(255)
+  createdAt            DateTime   @default(now())
+  updatedAt            DateTime   @updatedAt
+
+  @@unique([scheduledSurfaceGuid, scheduledDate], name: "ScheduledSurfaceDate")
+}
+
 enum CuratedStatus {
   RECOMMENDATION
   CORPUS


### PR DESCRIPTION
## Goal

add schedule review model to corpus API.

- this model will store a history of daily human curator schedule review

## Implementation Decisions

- while the strategy around scheduled notifications is being determined, i created this model for the most straightforward approach - the only way data is inserted is when a curator clicks a button in the admin tool, meaning all fields will be present on insert. this model may change once a schedule notification strategy is defined.
- to ease potential dev cleanup, i'll push this to dev after approval as a final test.

## Deployment steps

- [ ] Deployed to dev?

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1330