### PR TITLE
chore(snowplow): [MC-835] Remove pocket-backend references from content-engineering Snowplow events

### DIFF
--- a/packages/content-common/snowplow/config.ts
+++ b/packages/content-common/snowplow/config.ts
@@ -16,7 +16,7 @@ const config = {
     httpProtocol: environment === 'production' ? 'https' : 'http',
     bufferSize: 1,
     retries,
-    namespace: 'pocket-backend',
+    namespace: 'content',
   },
 };
 

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -70,8 +70,8 @@ export default {
     // https://github.com/Pocket/dbt-snowflake/blob/main/macros/validate_snowplow_app_id.sql
     appId:
       process.env.NODE_ENV === 'production'
-        ? 'pocket-backend-curated-corpus-api'
-        : 'pocket-backend-curated-corpus-api-dev',
+        ? 'curated-corpus-api'
+        : 'curated-corpus-api-dev',
     corpusItemEvents: ReviewedCorpusItemEventType,
     corpusScheduleEvents: ScheduledCorpusItemEventType,
     schemas: {

--- a/servers/prospect-api/src/config/index.ts
+++ b/servers/prospect-api/src/config/index.ts
@@ -32,8 +32,8 @@ export default {
     // https://github.com/Pocket/dbt-snowflake/blob/main/macros/validate_snowplow_app_id.sql
     appId:
       process.env.NODE_ENV === 'production'
-        ? 'pocket-backend-prospect-api'
-        : 'pocket-backend-prospect-api-dev',
+        ? 'prospect-api'
+        : 'prospect-api-dev',
     schemas: {
       // published 2024-01-26
       prospect: 'iglu:com.pocket/prospect/jsonschema/1-0-3',


### PR DESCRIPTION
## Goal

Clean up the code!

- Removed `pocket-backend-` prefix from two APIs.

## I'd love feedback/perspectives on:

- Renamed the `pocket-backend` namespace to `content` as it appears [we _have_ to set a namespace of some sort](https://github.com/Pocket/content-monorepo/blob/8ddcd90894c4abca71ab4fa6843e66aa08ddc6f8/packages/content-common/snowplow/index.ts#L53). Is there a more generic namespace value we should use instead? 


## References

JIRA ticket: https://mozilla-hub.atlassian.net/browse/MC-835