### PR TITLE
fix(corpus): linking the CorpusItem to the Item

### DIFF
--- a/servers/curated-corpus-api/schema-public.graphql
+++ b/servers/curated-corpus-api/schema-public.graphql
@@ -150,15 +150,14 @@ type SavedItem @key(fields: "url") {
   corpusItem: CorpusItem
 }
 
-# Commented out until RecsAPI implements the fields that lets us extend Recommendation
-#extend type Recommendation  @key(fields: "corpusItemId") {
-#    """
-#    key field to identify the CorpusItem entity in the RecsAPI service
-#    """
-#    corpusItemId: ID! @external
-#
-#    """
-#    If the item is in our corpus with metadata lets define it, this would replace the older curatedInfo object.
-#    """
-#    corpusItem: CorpusItem @requires(fields: "corpusItemId")
-#}
+type Item @key(fields: "givenUrl") {
+  """
+  key field to identify the CorpusItem entity in the RecsAPI service
+  """
+  givenUrl: Url! @external
+
+  """
+  If the item is in corpus allow the item to reference it.  Exposing curated info for consistent UX
+  """
+  corpusItem: CorpusItem
+}

--- a/servers/curated-corpus-api/src/public/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/index.ts
@@ -1,7 +1,11 @@
 import { DateResolver } from 'graphql-scalars';
 import { getScheduledSurface } from './queries/ScheduledSurface';
 import { getItemsForScheduledSurface } from './queries/ScheduledSurfaceItem';
-import { getCorpusItem, getSavedCorpusItem } from './queries/CorpusItem';
+import {
+  getCorpusItem,
+  getSavedCorpusItem,
+  getItemCorpusItem,
+} from './queries/CorpusItem';
 
 export const resolvers = {
   // The Date resolver enforces the date to be in the YYYY-MM-DD format.
@@ -17,6 +21,10 @@ export const resolvers = {
   // Allow the `SavedItem` to resolve the corpus item
   SavedItem: {
     corpusItem: getSavedCorpusItem,
+  },
+  // Allow the `Item` to resolve the corpus item
+  Item: {
+    corpusItem: getItemCorpusItem,
   },
   Query: {
     // Gets the metadata for a Scheduled Surface (for example, New Tab).

--- a/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -138,7 +138,7 @@ describe('CorpusItem reference resolver', () => {
     expect(result.body.data?._entities[0]).toBeNull();
   });
 
-  it('returns the corpus item if it exists', async () => {
+  it('returns the corpus item if it exists on savedItem', async () => {
     // Create an approved item.
     const approvedItem = await createApprovedItemHelper(db, {
       title: 'Story one',
@@ -163,10 +163,42 @@ describe('CorpusItem reference resolver', () => {
     expect(result.body.data).not.toBeNull();
     expect(result.body.data?._entities).toHaveLength(1);
     expect(result.body.data?._entities[0].corpusItem.title).toEqual(
-      approvedItem.title
+      approvedItem.title,
     );
     expect(result.body.data?._entities[0].corpusItem.authors).toHaveLength(
-      <number>approvedItem.authors?.length
+      <number>approvedItem.authors?.length,
+    );
+  });
+
+  it('returns the corpus item if it exists on Item', async () => {
+    // Create an approved item.
+    const approvedItem = await createApprovedItemHelper(db, {
+      title: 'Story one',
+    });
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .send({
+        query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
+        variables: {
+          representations: [
+            {
+              __typename: 'Item',
+              givenUrl: approvedItem.url,
+            },
+          ],
+        },
+      });
+
+    expect(result.body.errors).toBeUndefined();
+
+    expect(result.body.data).not.toBeNull();
+    expect(result.body.data?._entities).toHaveLength(1);
+    expect(result.body.data?._entities[0].corpusItem.title).toEqual(
+      approvedItem.title,
+    );
+    expect(result.body.data?._entities[0].corpusItem.authors).toHaveLength(
+      <number>approvedItem.authors?.length,
     );
   });
 

--- a/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.ts
@@ -37,3 +37,18 @@ export async function getSavedCorpusItem(
 
   return getCorpusItemFromApprovedItem(approvedItem);
 }
+
+export async function getItemCorpusItem(
+  item,
+  args,
+  { db },
+): Promise<CorpusItem> {
+  const { givenUrl } = item;
+
+  const approvedItem = await getApprovedItemByUrl(db, givenUrl);
+  if (!approvedItem) {
+    return null;
+  }
+
+  return getCorpusItemFromApprovedItem(approvedItem);
+}

--- a/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
@@ -61,6 +61,15 @@ export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
           }
         }
       }
+      ... on Item {
+        corpusItem {
+          id
+          title
+          authors {
+            name
+          }
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
## Goal

Pocket is looking to standardize all of our display logic for any particular "Item" server side. To do this as a starting point, we need the Item to link to CorpusItem so we can so the curator metadata across all of Pocket if it exists for any givenUrl.

Ref: https://github.com/Pocket/pocket-monorepo/pull/697