### PR TITLE
feat: add scheduled surface guid/scheduled date index to scheduled item table

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20240925184524_add_scheduled_surface_guid_scheduled_date_index_on_scheduled_item/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20240925184524_add_scheduled_surface_guid_scheduled_date_index_on_scheduled_item/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX `ScheduledSurfaceGuidScheduledDate` ON `ScheduledItem`(`scheduledSurfaceGuid`, `scheduledDate`);

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -82,6 +82,8 @@ model ScheduledItem {
 
   @@unique([approvedItemId, scheduledSurfaceGuid, scheduledDate], name: "ItemScheduledSurfaceDate")
   @@index([scheduledSurfaceGuid])
+  // this index exists to assist serving content to new tab, which requests by surface and date
+  @@index([scheduledSurfaceGuid, scheduledDate], name: "ScheduledSurfaceGuidScheduledDate")
 }
 
 model ScheduleReview {


### PR DESCRIPTION
## Goal

improve query performance when New Tab requests the day's schedule.

- index exists to improve performance for new tab requesting the day's sched

## Implementation Decisions

- turned on performance insights on the database and watched for a week. the query from New Tab was by far the most taxing. took the query being performed into a GUI and ran `EXPLAIN` on it - which showed it was not using an index (instead using `WHERE`, which is more costly). manually added the index in this PR on dev and saw query execution speed much improved, and `EXPLAIN` used the index instead of `WHERE`.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1510