### PR TITLE
fix: handle null item.resolvedUrl on Item.corpusItem resolver

### DIFF
--- a/servers/curated-corpus-api/src/public/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/index.ts
@@ -39,13 +39,21 @@ export const resolvers = {
     corpusItem: async (item, args, context: IPublicContext) => {
       const { givenUrl, resolvedUrl } = item;
 
-      const corpusItem =
-        (await context.dataLoaders.corpusItemsByUrl.load(givenUrl)) ??
-        // If a record is not found for a givenUrl, it could be that
-        // the URL changed -- try the resolvedUrl
-        (await context.dataLoaders.corpusItemsByUrl.load(resolvedUrl));
+      // try to get the corpusItem by the item's givenUrl
+      let corpusItem = await context.dataLoaders.corpusItemsByUrl.load(
+        givenUrl,
+      );
 
-      return corpusItem;
+      // if the item's givenUrl didn't return a corpusItem, and if the item has
+      // a resolvedUrl, try finding the corpusItem by resolvedUrl
+      if (!corpusItem && resolvedUrl) {
+        corpusItem = await context.dataLoaders.corpusItemsByUrl.load(
+          resolvedUrl,
+        );
+      }
+
+      // return the corpusItem or null
+      return corpusItem || null;
     },
   },
   Query: {

--- a/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -547,7 +547,7 @@ describe('CorpusItem reference resolver', () => {
       );
     });
 
-    it('should return null on Item if the url provided is not known', async () => {
+    it('should return null on Item if the givenUrl and resolvedUrl provided are not known', async () => {
       const result = await request(app)
         .post(graphQLUrl)
         .send({
@@ -558,6 +558,27 @@ describe('CorpusItem reference resolver', () => {
                 __typename: 'Item',
                 givenUrl: 'ABRACADABRA',
                 resolvedUrl: 'ABRACADABRA',
+              },
+            ],
+          },
+        });
+
+      expect(result.body.errors).toBeUndefined();
+      expect(result.body.data?._entities).toHaveLength(1);
+      expect(result.body.data?._entities[0].corpusItem).toBeNull();
+    });
+
+    it('should return null on Item if the givenUrl provided is not known and resolvedUrl is null', async () => {
+      const result = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
+          variables: {
+            representations: [
+              {
+                __typename: 'Item',
+                givenUrl: 'ABRACADABRA',
+                resolvedUrl: null,
               },
             ],
           },


### PR DESCRIPTION
## Goal

handle the use case when an `Item`'s `givenUrl` does not return a `corpusItem`, and the `Item`'s `resolvedUrl` is `null`.

when this code was originally implemented, it was assumed that all `Item`s had a non-null `resolvedUrl`, which is not the case.

## References

Sentry issue:

- https://pocket.sentry.io/issues/5999730025/?environment=production&project=5938284&query=start%3D2024-10-17T19%3A09%3A00%26end%3D2024-10-18T14%3A21%3A32%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream