### PR TITLE
chore: remove AWS OTEL from collection API

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,13 +394,13 @@ importers:
         version: link:../../packages/eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20240924)
+        version: 2.4.7(typescript@5.7.0-dev.20241021)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)))(typescript@5.7.0-dev.20240924)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)))(typescript@5.7.0-dev.20241021)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -428,22 +428,22 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20240924)
+        version: 2.4.7(typescript@5.7.0-dev.20241021)
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)))(typescript@5.7.0-dev.20240924)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)))(typescript@5.7.0-dev.20241021)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.7.0-dev.20240924)
+        version: 8.2.4(typescript@5.7.0-dev.20241021)
 
   packages/eslint-config-custom:
     devDependencies:
@@ -556,19 +556,19 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20240924)
+        version: 2.4.7(typescript@5.7.0-dev.20241021)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)))(typescript@5.7.0-dev.20240924)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)))(typescript@5.7.0-dev.20241021)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.7.0-dev.20240924)
+        version: 8.2.4(typescript@5.7.0-dev.20241021)
 
   packages/tsconfig:
     dependencies:
@@ -611,9 +611,6 @@ importers:
       '@pocket-tools/apollo-utils':
         specifier: 3.5.0
         version: 3.5.0
-      '@pocket-tools/tracing':
-        specifier: 1.3.15
-        version: 1.3.15
       '@pocket-tools/ts-logger':
         specifier: ^1.6.0
         version: 1.9.2
@@ -6988,8 +6985,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.0-dev.20240924:
-    resolution: {integrity: sha512-Ij5R6dGDoRwlwMv0YAF0DSKOp2gGIv0SZNybFpAm05zZ/tktjetR7IrwuurvRlDEz7v91AC3ehs2lF7lJ8F/QA==}
+  typescript@5.7.0-dev.20241021:
+    resolution: {integrity: sha512-nf5PGykGkdF2Palp0anP/jjLiqM7jdLaIyhpq1Y8bhHnClE1JR2eHXrame54dWeaX0ZMc3NF/TD59xtVhZiuMA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8968,7 +8965,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -8982,7 +8979,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -11505,13 +11502,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)):
+  create-jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -11713,7 +11710,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20241021
 
   drange@1.1.1: {}
 
@@ -13134,16 +13131,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)):
+  jest-cli@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      create-jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13215,7 +13212,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)):
+  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -13241,7 +13238,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.14
-      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)
+      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13277,7 +13274,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)):
+  jest-config@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -13303,7 +13300,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.7.0
-      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)
+      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13547,12 +13544,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)):
+  jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      jest-cli: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -13985,7 +13982,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  msw@2.4.7(typescript@5.7.0-dev.20240924):
+  msw@2.4.7(typescript@5.7.0-dev.20241021):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -14005,7 +14002,7 @@ snapshots:
       type-fest: 4.26.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20241021
 
   mute-stream@0.0.8: {}
 
@@ -15232,17 +15229,17 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  ts-jest@29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924)))(typescript@5.7.0-dev.20240924):
+  ts-jest@29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021)))(typescript@5.7.0-dev.20241021):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924))
+      jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20241021
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.25.2
@@ -15320,7 +15317,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20240924):
+  ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241021):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -15334,7 +15331,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20241021
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -15389,7 +15386,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.2.4(typescript@5.7.0-dev.20240924):
+  tsup@8.2.4(typescript@5.7.0-dev.20241021):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -15408,7 +15405,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 5.7.0-dev.20240924
+      typescript: 5.7.0-dev.20241021
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -15512,7 +15509,7 @@ snapshots:
 
   typescript@5.6.2: {}
 
-  typescript@5.7.0-dev.20240924: {}
+  typescript@5.7.0-dev.20241021: {}
 
   typia@6.10.2(typescript@5.6.2):
     dependencies:

--- a/servers/collection-api/package.json
+++ b/servers/collection-api/package.json
@@ -36,7 +36,6 @@
     "@aws-sdk/client-s3": "3.529.1",
     "@aws-sdk/lib-storage": "3.529.1",
     "@pocket-tools/apollo-utils": "3.5.0",
-    "@pocket-tools/tracing": "1.3.15",
     "@pocket-tools/ts-logger": "^1.6.0",
     "@prisma/client": "5.20.0",
     "@sentry/node": "7.112.2",

--- a/servers/collection-api/src/main.ts
+++ b/servers/collection-api/src/main.ts
@@ -1,19 +1,11 @@
 // nodeSDKBuilder must be the first import!!
-import {
-  nodeSDKBuilder,
-  AdditionalInstrumentation,
-} from '@pocket-tools/tracing';
-
-import config from './config';
 import { serverLogger } from '@pocket-tools/ts-logger';
 
-nodeSDKBuilder({
-  host: config.tracing.host,
-  serviceName: config.tracing.serviceName,
-  release: config.sentry.release,
-  logger: serverLogger,
-  additionalInstrumentations: [AdditionalInstrumentation.PRISMA],
-}).then(async () => {
+import config from './config';
+
+import { startServer } from './express';
+
+(async () => {
   const { adminUrl, publicUrl } = await startServer(config.app.port);
 
   serverLogger.info(
@@ -23,6 +15,4 @@ nodeSDKBuilder({
   serverLogger.info(
     `🚀 Admin server is ready at http://localhost:${config.app.port}${adminUrl}`,
   );
-});
-
-import { startServer } from './express';
+})();


### PR DESCRIPTION
## Goal

remove AWS OTEL solution as it was proven faulty (RAM consumption) in corpus API.

deployed to dev and verified admin tool is working.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1563