### PR TITLE
chore: prisma update to 5.22.0

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -35,7 +35,7 @@
         "*prisma/**",
         "prisma"
       ],
-      "pinVersion": "5.20.0",
+      "pinVersion": "5.22.0",
       "label": "Prisma"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,13 +394,13 @@ importers:
         version: link:../../packages/eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20241022)
+        version: 2.4.7(typescript@5.8.0-dev.20241106)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)))(typescript@5.7.0-dev.20241022)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)))(typescript@5.8.0-dev.20241106)
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -428,22 +428,22 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20241022)
+        version: 2.4.7(typescript@5.8.0-dev.20241106)
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)))(typescript@5.7.0-dev.20241022)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)))(typescript@5.8.0-dev.20241106)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.7.0-dev.20241022)
+        version: 8.2.4(typescript@5.8.0-dev.20241106)
 
   packages/eslint-config-custom:
     devDependencies:
@@ -556,19 +556,19 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+        version: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.7.0-dev.20241022)
+        version: 2.4.7(typescript@5.8.0-dev.20241106)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)))(typescript@5.7.0-dev.20241022)
+        version: 29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)))(typescript@5.8.0-dev.20241106)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.7.0-dev.20241022)
+        version: 8.2.4(typescript@5.8.0-dev.20241106)
 
   packages/tsconfig:
     dependencies:
@@ -615,8 +615,8 @@ importers:
         specifier: ^1.6.0
         version: 1.9.2
       '@prisma/client':
-        specifier: 5.20.0
-        version: 5.20.0(prisma@5.20.0)
+        specifier: 5.22.0
+        version: 5.22.0(prisma@5.22.0)
       '@sentry/node':
         specifier: 7.112.2
         version: 7.112.2
@@ -648,8 +648,8 @@ importers:
         specifier: 2.1.35
         version: 2.1.35
       prisma:
-        specifier: 5.20.0
-        version: 5.20.0
+        specifier: 5.22.0
+        version: 5.22.0
       slugify:
         specifier: 1.6.6
         version: 1.6.6
@@ -740,7 +740,7 @@ importers:
         version: 3.529.1(@aws-sdk/client-s3@3.529.1)
       '@devoxa/prisma-relay-cursor-connection':
         specifier: 3.1.0
-        version: 3.1.0(@prisma/client@5.20.0(prisma@5.20.0))
+        version: 3.1.0(@prisma/client@5.22.0(prisma@5.22.0))
       '@pocket-tools/apollo-utils':
         specifier: 3.5.0
         version: 3.5.0
@@ -748,8 +748,8 @@ importers:
         specifier: ^1.6.0
         version: 1.9.2
       '@prisma/client':
-        specifier: 5.20.0
-        version: 5.20.0(prisma@5.20.0)
+        specifier: 5.22.0
+        version: 5.22.0(prisma@5.22.0)
       '@sentry/node':
         specifier: 7.112.2
         version: 7.112.2
@@ -799,8 +799,8 @@ importers:
         specifier: 2.1.35
         version: 2.1.35
       prisma:
-        specifier: 5.20.0
-        version: 5.20.0
+        specifier: 5.22.0
+        version: 5.22.0
       tslib:
         specifier: 2.7.0
         version: 2.7.0
@@ -2020,8 +2020,8 @@ packages:
   '@pocket-tools/ts-logger@1.9.2':
     resolution: {integrity: sha512-dK7tiQNSbHj/Oyn11VZHLlh65d8iq5TxYz5hz2uHxa+0uiB9wiIWBuHtg1GVpWHoEbAMGu6nVQqs8AqwUEJFNQ==}
 
-  '@prisma/client@5.20.0':
-    resolution: {integrity: sha512-CLv55ZuMuUawMsxoqxGtLT3bEZoa2W8L3Qnp6rDIFWy+ZBrUcOFKdoeGPSnbBqxc3SkdxJrF+D1veN/WNynZYA==}
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
     engines: {node: '>=16.13'}
     peerDependencies:
       prisma: '*'
@@ -2029,20 +2029,20 @@ packages:
       prisma:
         optional: true
 
-  '@prisma/debug@5.20.0':
-    resolution: {integrity: sha512-oCx79MJ4HSujokA8S1g0xgZUGybD4SyIOydoHMngFYiwEwYDQ5tBQkK5XoEHuwOYDKUOKRn/J0MEymckc4IgsQ==}
+  '@prisma/debug@5.22.0':
+    resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
 
-  '@prisma/engines-version@5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284':
-    resolution: {integrity: sha512-Lg8AS5lpi0auZe2Mn4gjuCg081UZf88k3cn0RCwHgR+6cyHHpttPZBElJTHf83ZGsRNAmVCZCfUGA57WB4u4JA==}
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
+    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
 
-  '@prisma/engines@5.20.0':
-    resolution: {integrity: sha512-DtqkP+hcZvPEbj8t8dK5df2b7d3B8GNauKqaddRRqQBBlgkbdhJkxhoJTrOowlS3vaRt2iMCkU0+CSNn0KhqAQ==}
+  '@prisma/engines@5.22.0':
+    resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
 
-  '@prisma/fetch-engine@5.20.0':
-    resolution: {integrity: sha512-JVcaPXC940wOGpCOwuqQRTz6I9SaBK0c1BAyC1pcz9xBi+dzFgUu3G/p9GV1FhFs9OKpfSpIhQfUJE9y00zhqw==}
+  '@prisma/fetch-engine@5.22.0':
+    resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
 
-  '@prisma/get-platform@5.20.0':
-    resolution: {integrity: sha512-8/+CehTZZNzJlvuryRgc77hZCWrUDYd/PmlZ7p2yNXtmf2Una4BWnTbak3us6WVdqoz5wmptk6IhsXdG2v5fmA==}
+  '@prisma/get-platform@5.22.0':
+    resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -5648,8 +5648,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prisma@5.20.0:
-    resolution: {integrity: sha512-6obb3ucKgAnsGS9x9gLOe8qa51XxvJ3vLQtmyf52CTey1Qcez3A6W6ROH5HIz5Q5bW+0VpmZb8WBohieMFGpig==}
+  prisma@5.22.0:
+    resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
     engines: {node: '>=16.13'}
     hasBin: true
 
@@ -6552,8 +6552,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.7.0-dev.20241022:
-    resolution: {integrity: sha512-Z8PXMDow1rJGCzBQ9FEeNQHBDEGwqSMAlaM00C9qn/DlUH7DC5dS/pNNEcrQBktPbbIwOjR4XuXYOddJUH2klQ==}
+  typescript@5.8.0-dev.20241106:
+    resolution: {integrity: sha512-oFqIoJnR/s4hq5I2MBDdeJThRVyyhRV5eo2EmxllNkSe76ycucq2h4QgWnq0g4Opf4KQjpi1m/jhgMoiwDc8CQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8142,9 +8142,9 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@devoxa/prisma-relay-cursor-connection@3.1.0(@prisma/client@5.20.0(prisma@5.20.0))':
+  '@devoxa/prisma-relay-cursor-connection@3.1.0(@prisma/client@5.22.0(prisma@5.22.0))':
     dependencies:
-      '@prisma/client': 5.20.0(prisma@5.20.0)
+      '@prisma/client': 5.22.0(prisma@5.22.0)
       graphql-fields: 2.0.3
 
   '@effect/schema@0.71.1(effect@3.6.5)':
@@ -8516,7 +8516,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -8530,7 +8530,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -8805,30 +8805,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@prisma/client@5.20.0(prisma@5.20.0)':
+  '@prisma/client@5.22.0(prisma@5.22.0)':
     optionalDependencies:
-      prisma: 5.20.0
+      prisma: 5.22.0
 
-  '@prisma/debug@5.20.0': {}
+  '@prisma/debug@5.22.0': {}
 
-  '@prisma/engines-version@5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284': {}
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
 
-  '@prisma/engines@5.20.0':
+  '@prisma/engines@5.22.0':
     dependencies:
-      '@prisma/debug': 5.20.0
-      '@prisma/engines-version': 5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284
-      '@prisma/fetch-engine': 5.20.0
-      '@prisma/get-platform': 5.20.0
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/fetch-engine': 5.22.0
+      '@prisma/get-platform': 5.22.0
 
-  '@prisma/fetch-engine@5.20.0':
+  '@prisma/fetch-engine@5.22.0':
     dependencies:
-      '@prisma/debug': 5.20.0
-      '@prisma/engines-version': 5.20.0-12.06fc58a368dc7be9fbbbe894adf8d445d208c284
-      '@prisma/get-platform': 5.20.0
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/get-platform': 5.22.0
 
-  '@prisma/get-platform@5.20.0':
+  '@prisma/get-platform@5.22.0':
     dependencies:
-      '@prisma/debug': 5.20.0
+      '@prisma/debug': 5.22.0
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -10535,13 +10535,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)):
+  create-jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10743,7 +10743,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20241022
+      typescript: 5.8.0-dev.20241106
 
   drange@1.1.1: {}
 
@@ -12149,16 +12149,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)):
+  jest-cli@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      create-jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      jest-config: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -12230,7 +12230,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)):
+  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -12256,7 +12256,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.14
-      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)
+      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12292,7 +12292,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)):
+  jest-config@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -12318,7 +12318,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.7.0
-      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)
+      ts-node: 10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12562,12 +12562,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)):
+  jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      jest-cli: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12994,7 +12994,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  msw@2.4.7(typescript@5.7.0-dev.20241022):
+  msw@2.4.7(typescript@5.8.0-dev.20241106):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.0
       '@bundled-es-modules/statuses': 1.0.1
@@ -13014,7 +13014,7 @@ snapshots:
       type-fest: 4.26.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.7.0-dev.20241022
+      typescript: 5.8.0-dev.20241106
 
   mute-stream@0.0.8: {}
 
@@ -13373,9 +13373,9 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@5.20.0:
+  prisma@5.22.0:
     dependencies:
-      '@prisma/engines': 5.20.0
+      '@prisma/engines': 5.22.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -14185,17 +14185,17 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  ts-jest@29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022)))(typescript@5.7.0-dev.20241022):
+  ts-jest@29.1.2(@babel/core@7.25.2)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106)))(typescript@5.8.0-dev.20241106):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022))
+      jest: 29.7.0(@types/node@22.7.0)(ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.7.0-dev.20241022
+      typescript: 5.8.0-dev.20241106
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.25.2
@@ -14273,7 +14273,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.7.0)(typescript@5.7.0-dev.20241022):
+  ts-node@10.9.2(@types/node@22.7.0)(typescript@5.8.0-dev.20241106):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -14287,7 +14287,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.7.0-dev.20241022
+      typescript: 5.8.0-dev.20241106
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -14340,7 +14340,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.2.4(typescript@5.7.0-dev.20241022):
+  tsup@8.2.4(typescript@5.8.0-dev.20241106):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -14359,7 +14359,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 5.7.0-dev.20241022
+      typescript: 5.8.0-dev.20241106
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -14463,7 +14463,7 @@ snapshots:
 
   typescript@5.6.2: {}
 
-  typescript@5.7.0-dev.20241022: {}
+  typescript@5.8.0-dev.20241106: {}
 
   typia@6.10.2(typescript@5.6.2):
     dependencies:

--- a/servers/collection-api/package.json
+++ b/servers/collection-api/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/lib-storage": "3.529.1",
     "@pocket-tools/apollo-utils": "3.5.0",
     "@pocket-tools/ts-logger": "^1.6.0",
-    "@prisma/client": "5.20.0",
+    "@prisma/client": "5.22.0",
     "@sentry/node": "7.112.2",
     "@sentry/tracing": "7.112.2",
     "content-common": "workspace:*",
@@ -48,7 +48,7 @@
     "graphql-upload": "15.0.2",
     "graphql": "16.9.0",
     "mime-types": "2.1.35",
-    "prisma": "5.20.0",
+    "prisma": "5.22.0",
     "slugify": "1.6.6",
     "tslib": "2.7.0",
     "uuid": "9.0.1"

--- a/servers/curated-corpus-api/package.json
+++ b/servers/curated-corpus-api/package.json
@@ -40,7 +40,7 @@
     "@devoxa/prisma-relay-cursor-connection": "3.1.0",
     "@pocket-tools/apollo-utils": "3.5.0",
     "@pocket-tools/ts-logger": "^1.6.0",
-    "@prisma/client": "5.20.0",
+    "@prisma/client": "5.22.0",
     "@sentry/node": "7.112.2",
     "@sentry/tracing": "7.112.2",
     "@snowplow/node-tracker": "3.5.0",
@@ -57,7 +57,7 @@
     "luxon": "3.4.4",
     "metadata-scraper": "^0.2.61",
     "mime-types": "2.1.35",
-    "prisma": "5.20.0",
+    "prisma": "5.22.0",
     "tslib": "2.7.0",
     "uuid": "9.0.1"
   },


### PR DESCRIPTION
## Goal

update prisma to latest (5.22.0).

- this release has potential fixes for "timeout getting connection from connection pool" issues we intermittently experience

deployed to dev and things look fine.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1590