### PR TITLE
chore: reduce minimum ACU capacity for corpus DB

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -11,7 +11,12 @@ const snowplowEndpoint = isDev
   : 'd.getpocket.com';
 
 const rds = {
-  minCapacity: isDev ? 1 : 64, // TODO: do we need this high for min?
+  // set on 2024-12-04 after slowly reducing from 64 & monitoring performance.
+  // note - during the minimum ACU reduction period (~2 weeks), CPU usage never
+  // climbed over 1% - even with a minimum ACU of 4. we could potentially reduce
+  // the minimum down to 2 or lower, but of course upcoming product/system usage
+  // and changes should be considered.
+  minCapacity: isDev ? 1 : 4,
   maxCapacity: isDev ? 1 : 128, // max allowed by AWS for Aurora Serverless V2
 };
 


### PR DESCRIPTION
## Goal

reduce minimum ACU on corpus DB to better align with usage. note that through manual configuration, the corpus DB is already running with a minimum of 4, so this PR should effectively be a no-op. this PR cements the "4" value in code so subsequent deploys maintain the desired value.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1602