### PR TITLE
feat: ingest ML-supplied URL metadata with some prospects

### DIFF
--- a/lambdas/prospect-translation-lambda/src/events/snowplow.ts
+++ b/lambdas/prospect-translation-lambda/src/events/snowplow.ts
@@ -54,14 +54,13 @@ export const generateContext = (
  */
 export const generateSnowplowEntity = (
   prospect: Prospect,
-  prospectSource: string,
   runDetails: ProspectRunDetails,
   features: ProspectFeatures,
 ): SnowplowProspect => {
   return {
     object_version: 'new',
     prospect_id: prospect.prospectId,
-    prospect_source: prospectSource,
+    prospect_source: prospect.prospectType,
     scheduled_surface_id: prospect.scheduledSurfaceGuid,
     url: prospect.url,
     title: prospect.title,

--- a/lambdas/prospect-translation-lambda/src/index.integration.ts
+++ b/lambdas/prospect-translation-lambda/src/index.integration.ts
@@ -1,5 +1,6 @@
 import { setupServer } from 'msw/node';
 import { Callback, Context } from 'aws-lambda';
+import * as Sentry from '@sentry/serverless';
 
 import config from './config';
 
@@ -19,6 +20,8 @@ import {
  */
 describe('prospect api translation lambda entry function', () => {
   const server = setupServer();
+  const captureConsoleSpy = jest.spyOn(console, 'log').mockImplementation();
+  const sentrySpy = jest.spyOn(Sentry, 'captureException').mockImplementation();
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 
@@ -28,12 +31,14 @@ describe('prospect api translation lambda entry function', () => {
   });
 
   afterEach(() => {
-    // restoreAllMocks restores all mocks and replaced properties. clearAllMocks only clears mocks.
-    jest.restoreAllMocks();
+    // clear all mock history
+    jest.clearAllMocks();
     server.resetHandlers();
   });
 
   afterAll(() => {
+    // restore all mocks and replaced properties/methods
+    jest.restoreAllMocks();
     server.close();
   });
 
@@ -81,6 +86,7 @@ describe('prospect api translation lambda entry function', () => {
 
     // Check that the right Snowplow entity was included with the event.
     const goodEvents = await getGoodSnowplowEvents();
+
     for (let i = 0; i < 2; i++) {
       const snowplowContext = parseSnowplowData(
         goodEvents[i].rawEvent.parameters.cx,
@@ -119,8 +125,6 @@ describe('prospect api translation lambda entry function', () => {
       ],
     };
 
-    const captureConsoleSpy = jest.spyOn(console, 'log').mockImplementation();
-
     await processor(fakePayload, sqsContext, sqsCallback);
 
     expect(captureConsoleSpy).toHaveBeenCalledWith(
@@ -152,8 +156,6 @@ describe('prospect api translation lambda entry function', () => {
       ],
     };
 
-    const captureConsoleSpy = jest.spyOn(console, 'log').mockImplementation();
-
     await processor(fakePayload, sqsContext, sqsCallback);
 
     expect(captureConsoleSpy).toHaveBeenCalledWith(
@@ -161,5 +163,79 @@ describe('prospect api translation lambda entry function', () => {
     );
 
     expect(captureConsoleSpy).toHaveBeenCalledWith(`1 prospects had errors.`);
+  });
+
+  it('accepts prospects with ML-supplied URL metadata', async () => {
+    const fakePayload = {
+      Records: [
+        {
+          messageId: '1',
+          receiptHandle: 'handle',
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: 'time',
+            SenderId: 'sender id',
+            ApproximateFirstReceiveTimestamp: 'time',
+          },
+          messageAttributes: {},
+          md5OfMessageAttributes: null,
+          md5OfBody: 'ab6181399b03008ffaada54b68c77574',
+          eventSource: 'aws:sqs',
+          eventSourceARN:
+            'arn:aws:sqs:us-east-1:996905175585:ProspectAPI-Prod-Sqs-Translation-Queue',
+          awsRegion: 'us-east-1',
+          body: '{"version":"0","id":"ab02d85b-4cb6-9de9-b549-b572166b278f","detail-type":"prospect-generation","source":"prospect-events","account":"996905175585","time":"2024-04-16T00:05:59Z","region":"us-east-1","resources":[],"detail":{"id":"c71504d1-f14f-4181-a654-730d5855ec48","version":3,"candidates":[{"scheduled_surface_guid": "NEW_TAB_DE_DE", "prospect_id": "447c90d2-1084-5f83-a585-26edfbf5640e", "url": "https://www.spektrum.de/news/ninetyeast-ridge-eines-der-laengsten-gebirge-liegt-tief-unter-dem-meer/2246024", "prospect_source": "QA_SPORTS", "save_count": 0, "predicted_topic": "", "rank": 117, "data_source": "prospect", "title": "Eines der l\u00e4ngsten Gebirge liegt tief unter dem Meer", "excerpt": "Die Bergkette wurde durch ein seltenes vulkanisches Ph\u00e4nomen gebildet", "language": "EN", "image_url": "https://static.spektrum.de/fm/912/f1920x1080/triplejunction_gis_2014_lrg.8200272.png", "authors": ["Daniel Lingenh\u00f6hl"]},{"scheduled_surface_guid": "NEW_TAB_DE_DE", "prospect_id": "faa0631f-3a43-555a-9947-7ce3de165a92", "url": "https://www.spiegel.de/ausland/wahlen-in-thailand-wie-eine-kandidatin-fuer-ein-demokratischeres-thailand-kaempft-a-1fa52682-ca7a-45f9-816a-a031ca0a7950", "prospect_source": "QA_SPORTS", "save_count": 10, "predicted_topic": "POLITICS", "rank": 118, "data_source": "prospect", "title": "Parlamentswahlen in Thailand Frau Thamnitinans Kampf gegen die Putschisten", "excerpt": "Sie vertritt als Anwältin Regimegegner. Nun will Sasinan Thamnitinan sich im Parlament für mehr Demokratie in Thailand einsetzen. Unterwegs im ersten Wahlkampf nach den landesweiten Massenprotesten gegen das Militär.", "language": "DE", "image_url": "https://cdn.prod.www.spiegel.de/images/06720642-d6e0-42ed-a1e1-1ded9f79d1bd_w1280_r1.77_fpx68_fpy93.jpg", "authors": ["Maria Stöhr, DER SPIEGEL"]}]}}',
+        },
+      ],
+    };
+
+    await processor(fakePayload, sqsContext, sqsCallback);
+
+    expect(sentrySpy).toHaveBeenCalledTimes(0);
+
+    expect(captureConsoleSpy).toHaveBeenCalledWith(
+      `2 prospects inserted into dynamo.`,
+    );
+  });
+
+  it('should send errors to Sentry when ML-supplied URL metadata is invalid', async () => {
+    // this payload has three errors in the second/last prospect:
+    // - missing title
+    // - number given for authors
+    // - invalid language code
+    const fakePayload = {
+      Records: [
+        {
+          messageId: '1',
+          receiptHandle: 'handle',
+          attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: 'time',
+            SenderId: 'sender id',
+            ApproximateFirstReceiveTimestamp: 'time',
+          },
+          messageAttributes: {},
+          md5OfMessageAttributes: null,
+          md5OfBody: 'ab6181399b03008ffaada54b68c77574',
+          eventSource: 'aws:sqs',
+          eventSourceARN:
+            'arn:aws:sqs:us-east-1:996905175585:ProspectAPI-Prod-Sqs-Translation-Queue',
+          awsRegion: 'us-east-1',
+          body: '{"version":"0","id":"ab02d85b-4cb6-9de9-b549-b572166b278f","detail-type":"prospect-generation","source":"prospect-events","account":"996905175585","time":"2024-04-16T00:05:59Z","region":"us-east-1","resources":[],"detail":{"id":"c71504d1-f14f-4181-a654-730d5855ec48","version":3,"candidates":[{"scheduled_surface_guid": "NEW_TAB_DE_DE", "prospect_id": "447c90d2-1084-5f83-a585-26edfbf5640e", "url": "https://www.spektrum.de/news/ninetyeast-ridge-eines-der-laengsten-gebirge-liegt-tief-unter-dem-meer/2246024", "prospect_source": "QA_ENTERTAINMENT", "save_count": 0, "predicted_topic": "", "rank": 117, "data_source": "prospect", "title": "Eines der l\u00e4ngsten Gebirge liegt tief unter dem Meer", "excerpt": "Die Bergkette wurde durch ein seltenes vulkanisches Ph\u00e4nomen gebildet", "language": "EN", "image_url": "https://static.spektrum.de/fm/912/f1920x1080/triplejunction_gis_2014_lrg.8200272.png", "authors": ["Daniel Lingenh\u00f6hl"]},{"scheduled_surface_guid": "NEW_TAB_DE_DE", "prospect_id": "faa0631f-3a43-555a-9947-7ce3de165a92", "url": "https://www.spiegel.de/ausland/wahlen-in-thailand-wie-eine-kandidatin-fuer-ein-demokratischeres-thailand-kaempft-a-1fa52682-ca7a-45f9-816a-a031ca0a7950", "prospect_source": "QA_ENTERTAINMENT", "save_count": 10, "predicted_topic": "POLITICS", "rank": 118, "data_source": "prospect", "image_url": 16, "excerpt": "Sie vertritt als Anwältin Regimegegner. Nun will Sasinan Thamnitinan sich im Parlament für mehr Demokratie in Thailand einsetzen. Unterwegs im ersten Wahlkampf nach den landesweiten Massenprotesten gegen das Militär.", "language": "BB", "authors": 42}]}}',
+        },
+      ],
+    };
+
+    await processor(fakePayload, sqsContext, sqsCallback);
+
+    // authors, topic, and language are invalid in the test payload above
+    // - all should have triggered a Sentry call
+    expect(sentrySpy).toHaveBeenCalledTimes(3);
+
+    // the errors in ML-supplied URL metadata should *not* stop the prospects
+    // from being inserted!
+    expect(captureConsoleSpy).toHaveBeenCalledWith(
+      `2 prospects inserted into dynamo.`,
+    );
   });
 });

--- a/lambdas/prospect-translation-lambda/src/types.ts
+++ b/lambdas/prospect-translation-lambda/src/types.ts
@@ -1,11 +1,34 @@
+import { CorpusLanguage, ProspectType } from 'content-common';
+
 // this is the raw data from metaflow/sqs
 export interface SqsProspect {
-  prospect_id: string;
-  scheduled_surface_guid: string;
-  predicted_topic: string;
-  prospect_source: string;
   data_source?: string;
-  url: string;
-  save_count: number;
+  predicted_topic: string;
+  prospect_id: string;
+  prospect_source: string;
   rank: number;
+  save_count: number;
+  scheduled_surface_guid: string;
+  url: string;
+  // 2024-12-12
+  // some ML prospects will contain URL metadata to be used instead of Parser
+  // metadata. this is currently experimental, so all properties below are
+  // optional.
+  authors?: string[];
+  excerpt?: string;
+  image_url?: string;
+  language?: CorpusLanguage;
+  title?: string;
 }
+
+// 2024-12-12
+// noting which prospect types will have ML-supplied URL metadata. this is
+// likely a temporary array, as we should move to a consistent URL metadata
+// source for all prospect types.
+export const ProspectTypesWithMlUrlMetadata: ProspectType[] = [
+  ProspectType.QA_ENTERTAINMENT,
+  ProspectType.QA_GAMING,
+  ProspectType.QA_HISTORY,
+  ProspectType.QA_RELATIONSHIPS,
+  ProspectType.QA_SPORTS,
+];

--- a/packages/prospectapi-common/src/index.ts
+++ b/packages/prospectapi-common/src/index.ts
@@ -4,7 +4,7 @@
 
 export { DynamoItem, GetProspectsFilters, Prospect } from './types';
 export { ScheduledSurfaces, ScheduledSurface } from 'content-common';
-export { toUnixTimestamp, deriveUrlMetadata } from './lib';
+export { toUnixTimestamp, deriveDomainName, deriveUrlMetadata } from './lib';
 export {
   scanAllRows,
   generateInsertParams,


### PR DESCRIPTION
## Goal

ingest ML-supplied URL metadata for some prospect types. this is an experiment in the direction of reducing reliance on the parser. editors will be providing feedback to ML directly on the quality of the metadata.

- this will skip using the Parser for URL metadata for these prospects, _except_ for publisher name, which we still need to rely on the Parser for (for now)
- small refactoring/cleanup

intend to test this on dev prior to merging - will coordinate with ML.

## Implementation Decisions

- no additional data type/structure validation failures need to be implemented here, as we want any issues with ML-supplied URL metadata to be visible to the editors in the tool (as they are providing feedback there). i am sending any issues with the ML-supplied URL metadata to Sentry for added visibility.

## Deployment steps

- [x] Deployed to and verified on dev?

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1628