### PR TITLE
chore: DRY up pagerduty policy IDs

### DIFF
--- a/infrastructure/collection-api/package.json
+++ b/infrastructure/collection-api/package.json
@@ -23,7 +23,8 @@
     "@pocket-tools/terraform-modules": "5.14.2",
     "cdktf-cli": "0.20.8",
     "cdktf": "0.20.8",
-    "constructs": "10.3.0"
+    "constructs": "10.3.0",
+    "infrastructure-common": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "~20.12",

--- a/infrastructure/collection-api/src/config/index.ts
+++ b/infrastructure/collection-api/src/config/index.ts
@@ -1,3 +1,5 @@
+import { infraConfig } from 'infrastructure-common';
+
 const name = 'CollectionAPI';
 const domainPrefix = 'collection-api';
 const isDev = process.env.NODE_ENV === 'development';
@@ -26,6 +28,7 @@ export const config = {
   domain,
   graphqlVariant,
   rds,
+  pagerduty: infraConfig.pagerduty,
   tags: {
     service: name,
     environment,

--- a/infrastructure/collection-api/src/main.ts
+++ b/infrastructure/collection-api/src/main.ts
@@ -1,11 +1,5 @@
 import { Construct } from 'constructs';
-import {
-  App,
-  TerraformStack,
-  MigrateIds,
-  Aspects,
-  S3Backend,
-} from 'cdktf';
+import { App, TerraformStack, MigrateIds, Aspects, S3Backend } from 'cdktf';
 import { config } from './config';
 import {
   ApplicationRDSCluster,
@@ -162,8 +156,10 @@ class CollectionAPI extends TerraformStack {
       prefix: config.prefix,
       service: {
         // This is a Tier 2 service and as such only raises non-critical alarms.
-        criticalEscalationPolicyId: "PXOQVEP",
-        nonCriticalEscalationPolicyId: "PXOQVEP",
+        criticalEscalationPolicyId:
+          config.pagerduty.escalationPolicyIdNonCritical,
+        nonCriticalEscalationPolicyId:
+          config.pagerduty.escalationPolicyIdNonCritical,
       },
     });
   }

--- a/infrastructure/curated-corpus-api/package.json
+++ b/infrastructure/curated-corpus-api/package.json
@@ -23,7 +23,8 @@
     "@cdktf/provider-archive": "10.2.0",
     "cdktf": "0.20.8",
     "cdktf-cli": "0.20.8",
-    "constructs": "10.3.0"
+    "constructs": "10.3.0",
+    "infrastructure-common": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "~20.12",

--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -1,3 +1,5 @@
+import { infraConfig } from 'infrastructure-common';
+
 const name = 'CuratedCorpusAPI';
 const domainPrefix = 'curated-corpus-api';
 const isDev = process.env.NODE_ENV === 'development';
@@ -53,6 +55,7 @@ export const config = {
     timeout: 5,
     startPeriod: 0,
   },
+  pagerduty: infraConfig.pagerduty,
   tracing: {
     url: isDev
       ? 'https://otel-collector.getpocket.dev:443'

--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -1,11 +1,5 @@
 import { Construct } from 'constructs';
-import {
-  App,
-  TerraformStack,
-  MigrateIds,
-  Aspects,
-  S3Backend,
-} from 'cdktf';
+import { App, TerraformStack, MigrateIds, Aspects, S3Backend } from 'cdktf';
 import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
 import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
 import { LocalProvider } from '@cdktf/provider-local/lib/provider';
@@ -186,8 +180,9 @@ class CuratedCorpusAPI extends TerraformStack {
     return new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
-        criticalEscalationPolicyId: "PQ2EUPZ",
-        nonCriticalEscalationPolicyId: "PXOQVEP",
+        criticalEscalationPolicyId: config.pagerduty.escalationPolicyIdCritical,
+        nonCriticalEscalationPolicyId:
+          config.pagerduty.escalationPolicyIdNonCritical,
       },
     });
   }

--- a/infrastructure/prospect-api/src/config/index.ts
+++ b/infrastructure/prospect-api/src/config/index.ts
@@ -1,3 +1,5 @@
+import { infraConfig } from 'infrastructure-common';
+
 const name = 'ProspectAPI';
 const isDev = process.env.NODE_ENV === 'development';
 const githubConnectionArn = isDev
@@ -47,6 +49,7 @@ export const config = {
     eventBusName: `PocketEventBridge-${environment}-Shared-Event-Bus`,
     snowplowEndpoint,
   },
+  pagerduty: infraConfig.pagerduty,
   tags: {
     service: name,
     environment,

--- a/infrastructure/prospect-api/src/main.ts
+++ b/infrastructure/prospect-api/src/main.ts
@@ -1,11 +1,5 @@
 import { Construct } from 'constructs';
-import {
-  App,
-  TerraformStack,
-  MigrateIds,
-  Aspects,
-  S3Backend,
-} from 'cdktf';
+import { App, TerraformStack, MigrateIds, Aspects, S3Backend } from 'cdktf';
 
 import {
   PocketALBApplication,
@@ -119,8 +113,10 @@ class ProspectAPI extends TerraformStack {
       prefix: config.prefix,
       service: {
         // This is a Tier 2 service and as such only raises non-critical alarms.
-        criticalEscalationPolicyId: "PXOQVEP",
-        nonCriticalEscalationPolicyId: "PXOQVEP",
+        criticalEscalationPolicyId:
+          config.pagerduty.escalationPolicyIdNonCritical,
+        nonCriticalEscalationPolicyId:
+          config.pagerduty.escalationPolicyIdNonCritical,
       },
     });
   }

--- a/packages/infrastructure-common/config.ts
+++ b/packages/infrastructure-common/config.ts
@@ -1,0 +1,9 @@
+export const infraConfig = {
+  pagerduty: {
+    // these policy id values come directly from pagerduty.
+    // these ids should not change unless new policies are created in pagerduty,
+    // at which point we would need to update these values.
+    escalationPolicyIdCritical: 'PQ2EUPZ',
+    escalationPolicyIdNonCritical: 'PXOQVEP',
+  },
+};

--- a/packages/infrastructure-common/index.ts
+++ b/packages/infrastructure-common/index.ts
@@ -1,1 +1,2 @@
 export * from './dynamodb';
+export * from './config';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       dotenv-cli:
         specifier: latest
-        version: 7.4.4
+        version: 8.0.0
     devDependencies:
       syncpack:
         specifier: ^13.0.0
@@ -51,6 +51,9 @@ importers:
       constructs:
         specifier: 10.3.0
         version: 10.3.0
+      infrastructure-common:
+        specifier: workspace:*
+        version: link:../../packages/infrastructure-common
     devDependencies:
       '@types/node':
         specifier: ~20.12
@@ -137,6 +140,9 @@ importers:
       constructs:
         specifier: 10.3.0
         version: 10.3.0
+      infrastructure-common:
+        specifier: workspace:*
+        version: link:../../packages/infrastructure-common
     devDependencies:
       '@types/node':
         specifier: ~20.12
@@ -385,22 +391,22 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+        version: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.8.0-dev.20241121)
+        version: 2.4.7(typescript@5.8.0-dev.20250108)
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0(encoding@0.1.13)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)))(typescript@5.8.0-dev.20241121)
+        version: 29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)))(typescript@5.8.0-dev.20250108)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.8.0-dev.20241121)
+        version: 8.2.4(typescript@5.8.0-dev.20250108)
 
   packages/eslint-config-custom:
     devDependencies:
@@ -513,19 +519,19 @@ importers:
         version: link:../eslint-config-custom
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+        version: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       msw:
         specifier: 2.4.7
-        version: 2.4.7(typescript@5.8.0-dev.20241121)
+        version: 2.4.7(typescript@5.8.0-dev.20250108)
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)))(typescript@5.8.0-dev.20241121)
+        version: 29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)))(typescript@5.8.0-dev.20250108)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       tsup:
         specifier: 8.2.4
-        version: 8.2.4(typescript@5.8.0-dev.20241121)
+        version: 8.2.4(typescript@5.8.0-dev.20250108)
 
   packages/tsconfig:
     dependencies:
@@ -4295,8 +4301,8 @@ packages:
   domino@2.1.6:
     resolution: {integrity: sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==}
 
-  dotenv-cli@7.4.4:
-    resolution: {integrity: sha512-XkBYCG0tPIes+YZr4SpfFv76SQrV/LeCE8CI7JSEMi3VR9MvTihCGTOtbIexD6i2mXF+6px7trb1imVCXSNMDw==}
+  dotenv-cli@8.0.0:
+    resolution: {integrity: sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==}
     hasBin: true
 
   dotenv-expand@10.0.0:
@@ -7424,8 +7430,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.8.0-dev.20241121:
-    resolution: {integrity: sha512-6jaGeY7DfhSYIavJI6JeDMQFG5ezytKNOfXDThnyK7UI9MnMc3AxlPyjwJ1fAAAWQl8gf9nL7AvtPrPhGtxoKw==}
+  typescript@5.8.0-dev.20250108:
+    resolution: {integrity: sha512-EXcRljh+DJ7vqivS8Hu26PXlkFSkWsCwOyxEhR2P7l48WUjnAdw6kaNXDNTmQIgnipMdPACIHdc/DiyVlwtmCA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -9360,7 +9366,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -9374,7 +9380,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      jest-config: 29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12479,13 +12485,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)):
+  create-jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      jest-config: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12672,7 +12678,7 @@ snapshots:
 
   domino@2.1.6: {}
 
-  dotenv-cli@7.4.4:
+  dotenv-cli@8.0.0:
     dependencies:
       cross-spawn: 7.0.6
       dotenv: 16.4.5
@@ -12689,7 +12695,7 @@ snapshots:
     dependencies:
       semver: 7.6.3
       shelljs: 0.8.5
-      typescript: 5.8.0-dev.20241121
+      typescript: 5.8.0-dev.20250108
 
   drange@1.1.1: {}
 
@@ -14161,16 +14167,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)):
+  jest-cli@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      create-jest: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      jest-config: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -14242,7 +14248,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)):
+  jest-config@29.7.0(@types/node@20.12.14)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -14268,7 +14274,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.14
-      ts-node: 10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)
+      ts-node: 10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14304,7 +14310,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)):
+  jest-config@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -14330,7 +14336,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.9.1
-      ts-node: 10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)
+      ts-node: 10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14574,12 +14580,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)):
+  jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      jest-cli: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15068,7 +15074,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  msw@2.4.7(typescript@5.8.0-dev.20241121):
+  msw@2.4.7(typescript@5.8.0-dev.20250108):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -15088,7 +15094,7 @@ snapshots:
       type-fest: 4.27.0
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.8.0-dev.20241121
+      typescript: 5.8.0-dev.20250108
 
   murmurhash3js@3.0.1: {}
 
@@ -16354,17 +16360,17 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  ts-jest@29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121)))(typescript@5.8.0-dev.20241121):
+  ts-jest@29.1.2(@babel/core@7.26.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108)))(typescript@5.8.0-dev.20250108):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121))
+      jest: 29.7.0(@types/node@22.9.1)(ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.8.0-dev.20241121
+      typescript: 5.8.0-dev.20250108
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.26.0
@@ -16443,7 +16449,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20241121):
+  ts-node@10.9.2(@types/node@22.9.1)(typescript@5.8.0-dev.20250108):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -16457,7 +16463,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.0-dev.20241121
+      typescript: 5.8.0-dev.20250108
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -16512,7 +16518,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.2.4(typescript@5.8.0-dev.20241121):
+  tsup@8.2.4(typescript@5.8.0-dev.20250108):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -16531,7 +16537,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      typescript: 5.8.0-dev.20241121
+      typescript: 5.8.0-dev.20250108
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -16635,7 +16641,7 @@ snapshots:
 
   typescript@5.6.2: {}
 
-  typescript@5.8.0-dev.20241121: {}
+  typescript@5.8.0-dev.20250108: {}
 
   typia@6.12.0(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
## Goal

DRY up pagerduty policy IDs (added in #253)

- policy IDs recently added directly to codebase to move off terraform cloud
- Change 2

## Implementation Decisions

- just keeping the string values in one place instead of repeated across services