### PR TITLE
feat: delete associated SectionItems when deleting the parent ApprovedItem

### DIFF
--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -554,7 +554,6 @@ input CreateOrUpdateSectionInput {
   Indicates whether or not a Section is available for display.
   """
   active: Boolean!
-
 }
 
 extend type Section {
@@ -1232,6 +1231,7 @@ type Mutation {
 
   """
   Rejects an Approved Item: deletes it from the corpus and creates a Rejected Item instead.
+  Also deletes all associated SectionItems.
   """
   rejectApprovedCorpusItem(
     data: RejectApprovedCorpusItemInput!

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -215,7 +215,7 @@ export async function updateApprovedItem(
 
 /**
  * Removes an approved item from the corpus and adds its data to the rejected item
- * table.
+ * table. Also deletes all related SectionItems.
  *
  * @param parent
  * @param data

--- a/servers/curated-corpus-api/src/database/mutations/ApprovedItem.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/ApprovedItem.integration.ts
@@ -10,9 +10,10 @@ import {
 
 import { client } from '../client';
 
-import { clearDb } from '../../test/helpers';
+import { clearDb, createApprovedItemHelper } from '../../test/helpers';
 import { CreateApprovedItemInput } from '../types';
-import { createApprovedItem } from './ApprovedItem';
+import { createApprovedItem, deleteApprovedItem } from './ApprovedItem';
+import * as SectionItem from './SectionItem';
 
 describe('mutations: ApprovedItem', () => {
   let db: PrismaClient;
@@ -57,6 +58,25 @@ describe('mutations: ApprovedItem', () => {
       // Expect to see all the input data we supplied in the Approved Item
       expect(result).toMatchObject(input);
       expect(result.domainName).toStrictEqual('test.com');
+    });
+  });
+
+  describe('deleteApprovedItem db mutation', () => {
+    it('should call to delete all associated section items', async () => {
+      const deleteSectionItemSpy = jest.spyOn(
+        SectionItem,
+        'deleteSectionItemsByApprovedItemId',
+      );
+
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'testing!',
+      });
+
+      await deleteApprovedItem(db, approvedItem.externalId);
+
+      expect(deleteSectionItemSpy).toHaveBeenCalledTimes(1);
+
+      jest.restoreAllMocks();
     });
   });
 });

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -65,9 +65,8 @@ export async function createSectionItem(
  */
 export async function removeSectionItem(
   db: PrismaClient,
-  externalId: string
+  externalId: string,
 ): Promise<SectionItem> {
-  
   // Construct the data to remove SectionItem
   const removeSectionItemData = {
     active: false,
@@ -78,7 +77,7 @@ export async function removeSectionItem(
   return await db.sectionItem.update({
     where: {
       externalId,
-      active: true
+      active: true,
     },
     data: removeSectionItemData,
     include: {
@@ -90,5 +89,26 @@ export async function removeSectionItem(
         },
       },
     },
-  })
+  });
+}
+
+/**
+ * Deletes all SectionItems associated with the given ApprovedItem.
+ * This mutation is called when an ApprovedItem is deleted from the system
+ * (when rejecting a previously approved item).
+ *
+ * @param db
+ * @param approvedItemId number
+ */
+export async function deleteSectionItemsByApprovedItemId(
+  db: PrismaClient,
+  approvedItemId: number,
+): Promise<void> {
+  // TODO: we may want to emit an alaytics event here, as this action destroys
+  // corpus-level history on SectionItems
+  await db.sectionItem.deleteMany({
+    where: {
+      approvedItemId,
+    },
+  });
 }


### PR DESCRIPTION
## Goal

delete associated SectionItems when deleting the parent ApprovedItem. this is required for DB referential integrity, as a SectionItem is just a pointer to an ApprovedItem

## I'd love feedback/perspectives on:

- i know the test here is really just testing that Prisma does what we expect, but it feels like a good sanity check, particularly given that the operation is destructive.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1643