### PR TITLE
feat: section manager lambda - create section items

### DIFF
--- a/.github/workflows/section-manager-lambda.yml
+++ b/.github/workflows/section-manager-lambda.yml
@@ -19,14 +19,6 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/section-manager-lambda.yml'
 jobs:
-  test-integrations:
-    if: github.event_name == 'pull_request'
-    # this will reference the file below on the main branch
-    uses: pocket/pocket-monorepo/.github/workflows/reuse-test-integrations.yml@main
-    with:
-      scope: section-manager-lambda
-    secrets: inherit
-
   infrastructure:
     # this will reference the file below on the main branch
     uses: pocket/pocket-monorepo/.github/workflows/reuse-infrastructure.yml@main

--- a/lambdas/corpus-scheduler-lambda/src/types.ts
+++ b/lambdas/corpus-scheduler-lambda/src/types.ts
@@ -1,3 +1,5 @@
+import { tags } from 'typia';
+
 import {
   CorpusItemSource,
   CorpusLanguage,
@@ -5,7 +7,7 @@ import {
   Topics,
   ScheduledSurfacesEnum,
 } from 'content-common';
-import { tags } from 'typia';
+import { ApprovedCorpusItemOutput } from 'lambda-common';
 
 export interface ScheduledCandidates {
   candidates: ScheduledCandidate[];
@@ -52,11 +54,6 @@ export type ScheduledCorpusCandidateRunDetails = {
 
 interface ScheduledCorpusItemOutput {
   externalId: string;
-}
-
-export interface ApprovedCorpusItemOutput {
-  externalId: string;
-  url: string;
 }
 
 export interface ScheduledCorpusItemWithApprovedCorpusItemOutput

--- a/lambdas/section-manager-lambda/package.json
+++ b/lambdas/section-manager-lambda/package.json
@@ -8,7 +8,6 @@
     "test": "jest \"\\.spec\\.ts\"",
     "watch": "tsc -w & nodemon",
     "dev": "npm run build && npm run watch",
-    "test-integrations": "jest \"\\.integration\\.ts\" --runInBand",
     "lint": "eslint --fix-dry-run \"src/**/*.ts\"",
     "format": "eslint --fix \"src/**/*.ts\"",
     "prepare": "ts-patch install && typia patch"

--- a/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
+++ b/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
@@ -1,13 +1,58 @@
 import fetch from 'node-fetch';
 
-import { GraphQlApiCallHeaders } from 'lambda-common';
+import { CreateApprovedCorpusItemApiInput, UrlMetadata } from 'content-common';
+import {
+  ApprovedCorpusItemOutput,
+  getApprovedCorpusItemByUrl as getApprovedCorpusItemByUrlCommon,
+  getUrlMetadata as getUrlMetadataCommon,
+  GraphQlApiCallHeaders,
+} from 'lambda-common';
 
 import config from './config';
-import { CreateOrUpdateSectionApiInput } from './types';
+import {
+  CreateSectionItemApiInput,
+  CreateOrUpdateSectionApiInput,
+} from './types';
 
 export const sleep = async (ms: number) => {
   await new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+/**
+ * this function wraps the common function for the purposes of easily mocking in tests
+ *
+ * @param adminApiEndpoint string
+ * @param graphHeaders GraphQlApiHeaders object
+ * @param url string
+ * @returns Promise<ApprovedCorpusItemOutput>
+ */
+export async function getApprovedCorpusItemByUrl(
+  adminApiEndpoint: string,
+  graphHeaders: GraphQlApiCallHeaders,
+  url: string,
+): Promise<ApprovedCorpusItemOutput | null> {
+  return await getApprovedCorpusItemByUrlCommon(
+    adminApiEndpoint,
+    graphHeaders,
+    url,
+  );
+}
+
+/**
+ * this function wraps the common function for the purposes of easily mocking in tests
+ *
+ * @param adminApiEndpoint string
+ * @param graphHeaders GraphQlApiHeaders object
+ * @param url string
+ * @returns Promise<UrlMetadata>
+ */
+export async function getUrlMetadata(
+  adminApiEndpoint: string,
+  graphHeaders: GraphQlApiCallHeaders,
+  url: string,
+): Promise<UrlMetadata> {
+  return await getUrlMetadataCommon(adminApiEndpoint, graphHeaders, url);
+}
 
 /**
  * calls the createOrUpdateSection mutation to either create or update
@@ -55,3 +100,96 @@ export const createOrUpdateSection = async (
 
   return result.data.createOrUpdateSection.externalId;
 };
+
+/**
+ * Calls the createApprovedCorpusItem mutation in curated-corpus-api. Creates
+ * an ApproveItem in the corpus.
+ *
+ * @param adminApiEndpoint string
+ * @param graphHeaders GraphQlApiHeaders object
+ * @param data CreateApprovedCorpusItemApiInput
+ * @returns Promise<string> - the externalId of the ApprovedItem created
+ */
+export async function createApprovedCorpusItem(
+  adminApiEndpoint: string,
+  graphHeaders: GraphQlApiCallHeaders,
+  data: CreateApprovedCorpusItemApiInput,
+): Promise<string> {
+  // Wait, don't overwhelm the API
+  await sleep(2000);
+
+  const mutation = `
+    mutation CreateApprovedCorpusItem($data: CreateApprovedCorpusItemInput!) {
+      createApprovedCorpusItem(data: $data) {
+        externalId
+      }
+    }`;
+
+  const variables = { data };
+
+  const res = await fetch(adminApiEndpoint, {
+    method: 'post',
+    headers: graphHeaders,
+    body: JSON.stringify({ query: mutation, variables }),
+  });
+
+  const result = await res.json();
+
+  console.log(
+    `CreateApprovedCorpusItem MUTATION OUTPUT: ${JSON.stringify(result)}`,
+  );
+
+  // check for any errors returned by the mutation
+  if (!result.data && result.errors.length > 0) {
+    throw new Error(
+      `createApprovedCorpusItem mutation failed: ${result.errors[0].message}`,
+    );
+  }
+
+  return result.data.createApprovedCorpusItem.externalId;
+}
+
+/**
+ * Calls the createSectionItem mutation in curated-corpus-api. Creates a
+ * SectionItem in the corpus.
+ *
+ * @param adminApiEndpoint  string
+ * @param graphHeaders GraphQlApiHeaders object
+ * @param data CreateSectionItemApiInput
+ * @returns Promise<string> - externalId of the created SectionItem
+ */
+export async function createSectionItem(
+  adminApiEndpoint: string,
+  graphHeaders: GraphQlApiCallHeaders,
+  data: CreateSectionItemApiInput,
+): Promise<string> {
+  await sleep(2000);
+
+  const mutation = `
+    mutation CreateSectionItem($data: CreateSectionItemInput!) {
+      createSectionItem(data: $data) {
+        externalId
+      }
+    }`;
+
+  const variables = { data };
+
+  const res = await fetch(adminApiEndpoint, {
+    method: 'post',
+    headers: graphHeaders,
+    body: JSON.stringify({ query: mutation, variables }),
+  });
+
+  const result = await res.json();
+
+  console.log(`CreateSectionItem MUTATION OUTPUT: ${JSON.stringify(result)}`);
+
+  // check for any errors returned by the mutation
+  if (!result.data && result.errors.length > 0) {
+    throw new Error(
+      `createSectionItem mutation failed: ${result.errors[0].message}`,
+    );
+  }
+
+  return result.data.createSectionItem.externalId;
+}

--- a/lambdas/section-manager-lambda/src/index.integration.ts
+++ b/lambdas/section-manager-lambda/src/index.integration.ts
@@ -1,5 +1,0 @@
-describe('index integration tests', () => {
-  it('should pass', async () => {
-    expect(1).toEqual(1);
-  });
-});

--- a/lambdas/section-manager-lambda/src/index.spec.ts
+++ b/lambdas/section-manager-lambda/src/index.spec.ts
@@ -1,0 +1,95 @@
+import * as Sentry from '@sentry/serverless';
+import { Callback, Context, SQSEvent } from 'aws-lambda';
+
+import { processor } from './index';
+import { createSqsSectionWithSectionItems } from './testHelpers';
+import * as Jwt from './jwt';
+import * as Utils from './utils';
+import * as Validators from './validators';
+
+describe('processor', () => {
+  // mock functions that are possibly called from entry function
+  const mockGetJwtBearerToken = jest
+    .spyOn(Jwt, 'getJwtBearerToken')
+    .mockResolvedValue('jwtToken');
+
+  const mockProcessSqsSectionData = jest
+    .spyOn(Utils, 'processSqsSectionData')
+    .mockResolvedValue();
+
+  const mockSentryCaptureException = jest
+    .spyOn(Sentry, 'captureException')
+    .mockImplementation();
+
+  const mockValidateSqsData = jest
+    .spyOn(Validators, 'validateSqsData')
+    .mockReturnValue();
+
+  // needed to match call signature to entry function
+  const sqsCallback = null as unknown as Callback;
+  const sqsContext = null as unknown as Context;
+
+  afterEach(() => {
+    // clear all information/history about mocked functions
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    // restore original implementation of mocked functions
+    jest.restoreAllMocks();
+  });
+
+  it('should call processing functions if SQS message has only one record', async () => {
+    // create a valid payload
+    const payload = createSqsSectionWithSectionItems();
+
+    // create an SQS event using the valid payload
+    const sqsEvent = {
+      Records: [
+        {
+          messageId: '1',
+          body: JSON.stringify(payload),
+        },
+      ],
+    } as any as SQSEvent;
+
+    // initiate the lambda entry function
+    await processor(sqsEvent, sqsContext, sqsCallback);
+
+    expect(mockValidateSqsData).toHaveBeenCalledTimes(1);
+    expect(mockGetJwtBearerToken).toHaveBeenCalledTimes(1);
+    expect(mockProcessSqsSectionData).toHaveBeenCalledTimes(1);
+    expect(mockSentryCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('should call sentry and no processing functions if SQS message has more than one record', async () => {
+    // create two valid payloads
+    const payload1 = createSqsSectionWithSectionItems();
+    const payload2 = createSqsSectionWithSectionItems();
+
+    // create an invalid SQS event with two records
+    const sqsEvent = {
+      Records: [
+        {
+          messageId: '1',
+          body: JSON.stringify(payload1),
+        },
+        {
+          messageId: '2',
+          body: JSON.stringify(payload2),
+        },
+      ],
+    } as any as SQSEvent;
+
+    // initiate the lambda entry function
+    await processor(sqsEvent, sqsContext, sqsCallback);
+
+    expect(mockValidateSqsData).toHaveBeenCalledTimes(0);
+    expect(mockGetJwtBearerToken).toHaveBeenCalledTimes(0);
+    expect(mockProcessSqsSectionData).toHaveBeenCalledTimes(0);
+    expect(mockSentryCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(
+      `expected 1 record in SQS message, received ${sqsEvent.Records.length}`,
+    );
+  });
+});

--- a/lambdas/section-manager-lambda/src/index.ts
+++ b/lambdas/section-manager-lambda/src/index.ts
@@ -20,8 +20,6 @@ Sentry.AWSLambda.init({
  *  Lambda batchSize is 1 to avoid retrying successfully processed records.
  */
 export const processor: SQSHandler = async (event: SQSEvent) => {
-  console.log('Section Manager Lambda invoked...');
-
   // due to SQS message size limit of 256kb, this lambda is expected to process
   // one Section per SQS message
 
@@ -39,10 +37,17 @@ export const processor: SQSHandler = async (event: SQSEvent) => {
     event.Records[0].body,
   );
 
+  // during testing, log the data coming in from SQS/ML
+  console.log(sqsSectionData);
+
   validateSqsData(sqsSectionData);
 
+  // retrieve JWT bearer token for use in graph calls
   const jwtBearerToken = await getJwtBearerToken();
 
+  // create or update section
+  // create approved items (if url doesn't already exist in the corpus)
+  // create section items
   await processSqsSectionData(sqsSectionData, jwtBearerToken);
 };
 

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -37,3 +37,9 @@ export type CreateOrUpdateSectionApiInput = {
   sort?: number;
   title: string;
 };
+
+export type CreateSectionItemApiInput = {
+  approvedItemExternalId: string;
+  sectionExternalId: string;
+  rank?: number;
+};

--- a/lambdas/section-manager-lambda/src/validators.spec.ts
+++ b/lambdas/section-manager-lambda/src/validators.spec.ts
@@ -2,7 +2,6 @@ import { createSqsSectionWithSectionItems } from './testHelpers';
 import { CorpusItemSource, ScheduledSurfacesEnum } from 'content-common';
 import { validateSqsData } from './validators';
 
-// Referenced from: https://github.com/Pocket/curation-tools-data-sync/blob/main/curation-authors-backfill/jwt.spec.ts
 describe('validation', function () {
   afterEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
## Goal

section manager lambda - create section items

- move index integration tests to spec tests (all external calls are mocked)
- remove integration test job from CI (no .integration.ts files exist)

pushed to dev and sent a test payload through SQS - all worked as expected! we'll be testing this further in dev with real ML payloads before going live.

## Deployment steps

- [x] Deployed to dev?

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1645