### PR TITLE
MC-1671: adding Sections to ActionScreen enum

### DIFF
--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -59,6 +59,7 @@ export enum ActionScreen {
   PROSPECTING = 'PROSPECTING',
   SCHEDULE = 'SCHEDULE',
   CORPUS = 'CORPUS',
+  SECTIONS = 'SECTIONS'
 }
 
 export type ApprovedItemRequiredInput = {

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -185,6 +185,10 @@ enum ActionScreen {
   This action took place from the corpus screen in the admin tool
   """
   CORPUS
+  """
+  This action took place from the sections screen in the admin tool
+  """
+  SECTIONS
 }
 
 """

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -79,7 +79,7 @@ export default {
     schemas: {
       objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-5',
       reviewedCorpusItem:
-        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-8',
+        'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-11',
       scheduledCorpusItem:
         'iglu:com.pocket/scheduled_corpus_item/jsonschema/1-0-8',
     },


### PR DESCRIPTION
## Goal

Adding "Sections" to `ActionScreen` enum for indicating where an action took place from in the admin tool.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1671
