### PR TITLE
refactor: type validation in corpus scheduler and section manager lambdas

### DIFF
--- a/lambdas/corpus-scheduler-lambda/src/types.ts
+++ b/lambdas/corpus-scheduler-lambda/src/types.ts
@@ -26,11 +26,11 @@ export interface ScheduledCorpusItem {
   topic: Topics; // Empty string means unknown topic
   scheduled_date: string; // YYYY-MM-DD
   scheduled_surface_guid: ScheduledSurfacesEnum;
-  title?: string;
-  excerpt?: string;
-  language?: CorpusLanguage;
-  image_url?: string;
-  authors?: string[];
+  title: string | null;
+  excerpt: string | null;
+  language: CorpusLanguage | null;
+  image_url: string | null;
+  authors: string[] | null;
 }
 
 export const allowedScheduledSurfaces: string[] = [

--- a/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
@@ -289,7 +289,7 @@ describe('utils', function () {
 
     it('should throw Error on CreateApprovedItemInput if field types are wrong (title)', async () => {
       const scheduledCandidate = createScheduledCandidate();
-      scheduledCandidate.scheduled_corpus_item.title = undefined;
+      scheduledCandidate.scheduled_corpus_item.title = null;
       parserItem.title = undefined;
 
       await expect(

--- a/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
@@ -251,7 +251,7 @@ describe('validation', function () {
       expect(() => {
         validateCandidate(badScheduledCandidate);
       }).toThrow(
-        'Error on assert(): invalid type on $input.scheduled_corpus_item.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | undefined)',
+        'Error on assert(): invalid type on $input.scheduled_corpus_item.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | null)',
       );
     });
 
@@ -265,6 +265,55 @@ describe('validation', function () {
         validateCandidate(badScheduledCandidate);
       }).toThrow(
         'Error on assert(): invalid type on $input.scheduled_corpus_item.scheduled_surface_guid, expect to be ("NEW_TAB_DE_DE" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_ES_ES" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
+      );
+    });
+
+    // unfortunately, typia's error messages are not consistent, so we need two
+    // tests to verify handling of optional properties
+    it.each([
+      ['excerpt', 'string'],
+      ['image_url', 'string'],
+      ['title', 'string'],
+    ])('should validate optional string properties', (field, type) => {
+      const badScheduledCandidate = createScheduledCandidate() as any;
+
+      // null is a valid value from ML
+      badScheduledCandidate.scheduled_corpus_item[field] = null;
+
+      expect(() => {
+        validateCandidate(badScheduledCandidate);
+      }).not.toThrow();
+
+      // undefined is NOT a valid value from ML
+      delete badScheduledCandidate.scheduled_corpus_item[field];
+
+      expect(() => {
+        validateCandidate(badScheduledCandidate);
+      }).toThrow(
+        `Error on assert(): invalid type on $input.scheduled_corpus_item.${field}, expect to be (null | ${type})`,
+      );
+    });
+
+    it.each([
+      ['authors', 'Array<string>'],
+      ['language', '"DE" | "EN" | "ES" | "FR" | "IT"'],
+    ])('should validate optional non-string properties', (field, type) => {
+      const badScheduledCandidate = createScheduledCandidate() as any;
+
+      // null is a valid value from ML
+      badScheduledCandidate.scheduled_corpus_item[field] = null;
+
+      expect(() => {
+        validateCandidate(badScheduledCandidate);
+      }).not.toThrow();
+
+      // undefined is NOT a valid value from ML
+      delete badScheduledCandidate.scheduled_corpus_item[field];
+
+      expect(() => {
+        validateCandidate(badScheduledCandidate);
+      }).toThrow(
+        `Error on assert(): invalid type on $input.scheduled_corpus_item.${field}, expect to be (${type} | null)`,
       );
     });
 

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -17,14 +17,14 @@ export interface SqsSectionWithSectionItems {
 }
 
 export interface SqsSectionItem {
-  authors?: string[];
-  excerpt?: string;
-  image_url?: string;
-  language?: CorpusLanguage;
+  authors: string[] | null;
+  excerpt: string | null;
+  image_url: string | null;
+  language: CorpusLanguage | null;
   rank: number;
   source: CorpusItemSource.ML;
   status: CuratedStatus;
-  title?: string;
+  title: string | null;
   topic: Topics;
   url: string;
 }

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -136,10 +136,10 @@ describe('utils', () => {
       mockPocketImageCache(200);
 
       // remove preferred SQS values
-      delete sqsSectionItem.excerpt;
-      delete sqsSectionItem.image_url;
-      delete sqsSectionItem.language;
-      delete sqsSectionItem.title;
+      sqsSectionItem.excerpt = null;
+      sqsSectionItem.image_url = null;
+      sqsSectionItem.language = null;
+      sqsSectionItem.title = null;
 
       // remove preferred Parser values
       delete urlMetadata.authors;
@@ -184,7 +184,7 @@ describe('utils', () => {
       mockPocketImageCache(200);
 
       // remove title from both sources
-      delete sqsSectionItem.title;
+      sqsSectionItem.title = null;
       delete urlMetadata.title;
 
       await expect(
@@ -207,11 +207,11 @@ describe('utils', () => {
       mockPocketImageCache(200);
 
       // remove all optional SQS data
-      delete sqsSectionItem.authors;
-      delete sqsSectionItem.excerpt;
-      delete sqsSectionItem.image_url;
-      delete sqsSectionItem.language;
-      delete sqsSectionItem.title;
+      sqsSectionItem.authors = null;
+      sqsSectionItem.excerpt = null;
+      sqsSectionItem.image_url = null;
+      sqsSectionItem.language = null;
+      sqsSectionItem.title = null;
 
       // remove all optional Parser data
       delete urlMetadata.authors;

--- a/lambdas/section-manager-lambda/src/validators.spec.ts
+++ b/lambdas/section-manager-lambda/src/validators.spec.ts
@@ -155,5 +155,50 @@ describe('validation', function () {
         );
       });
     });
+
+    // unfortunately, typia's error messages are not consistent, so we need two
+    // tests to verify handling of optional properties
+    it.each([
+      ['excerpt', 'string'],
+      ['image_url', 'string'],
+      ['title', 'string'],
+    ])('should validate optional string properties', (field, type) => {
+      // null is a valid value from ML
+      sqsData.candidates[0][field] = null;
+
+      expect(() => {
+        validateSqsData(sqsData);
+      }).not.toThrow();
+
+      // undefined is NOT a valid value from ML
+      delete sqsData.candidates[0][field];
+
+      expect(() => {
+        validateSqsData(sqsData);
+      }).toThrow(
+        `Error on assert(): invalid type on $input.candidates[0].${field}, expect to be (null | ${type})`,
+      );
+    });
+
+    it.each([
+      ['authors', 'Array<string>'],
+      ['language', '"DE" | "EN" | "ES" | "FR" | "IT"'],
+    ])('should validate optional non-string properties', (field, type) => {
+      // null is a valid value from ML
+      sqsData.candidates[0][field] = null;
+
+      expect(() => {
+        validateSqsData(sqsData);
+      }).not.toThrow();
+
+      // undefined is NOT a valid value from ML
+      delete sqsData.candidates[0][field];
+
+      expect(() => {
+        validateSqsData(sqsData);
+      }).toThrow(
+        `Error on assert(): invalid type on $input.candidates[0].${field}, expect to be (${type} | null)`,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Goal

refactor type validation in corpus scheduler and section manager lambdas

- for optional fields, ML is sending `null`. our types expected `undefined`. this commit updates types for optional fields to accept `{type}` or `null`

## Implementation Decisions

- ML has confirmed that all optional fields will always be sent with each payload, with a value of `null` if the field value cannot be derived.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1675