### PR TITLE
fix: fix bug when hydrating prospect with language without title or excerpt

### DIFF
--- a/lambdas/prospect-translation-lambda/src/lib.spec.ts
+++ b/lambdas/prospect-translation-lambda/src/lib.spec.ts
@@ -562,6 +562,21 @@ describe('lib', () => {
         hydrateProspectMetadata(prospectToHydrate, urlMetadata),
       );
     });
+
+    it('should process a prospect with a language but without a title and excerpt', () => {
+      const expectedProspect: Prospect = {
+        ...expected,
+        excerpt: undefined,
+        title: undefined,
+      };
+
+      urlMetadata.title = undefined;
+      urlMetadata.excerpt = undefined;
+
+      expect(expectedProspect).toEqual(
+        hydrateProspectMetadata(prospectToHydrate, urlMetadata),
+      );
+    });
   });
 
   describe('getProspectRunDetailsFromMessageJson', () => {

--- a/lambdas/prospect-translation-lambda/src/lib.ts
+++ b/lambdas/prospect-translation-lambda/src/lib.ts
@@ -480,11 +480,13 @@ export const hydrateProspectMetadata = (
 
   // apply title/excerpt formatting for EN & DE
   if (prospect.language?.toUpperCase() === CorpusLanguage.EN) {
-    prospect.title = formatQuotesEN(applyApTitleCase(prospect.title)) as string;
-    prospect.excerpt = formatQuotesEN(prospect.excerpt) as string;
+    prospect.title =
+      prospect.title && formatQuotesEN(applyApTitleCase(prospect.title));
+    prospect.excerpt = prospect.excerpt && formatQuotesEN(prospect.excerpt);
   } else if (prospect.language?.toUpperCase() === CorpusLanguage.DE) {
-    prospect.title = formatQuotesDashesDE(prospect.title) as string;
-    prospect.excerpt = formatQuotesDashesDE(prospect.excerpt) as string;
+    prospect.title = prospect.title && formatQuotesDashesDE(prospect.title);
+    prospect.excerpt =
+      prospect.excerpt && formatQuotesDashesDE(prospect.excerpt);
   }
 
   return prospect;


### PR DESCRIPTION
## Goal

fix bug when hydrating prospect with language without title or excerpt. addresses [this](https://pocket.sentry.io/issues/6358932511/?alert_rule_id=15181376&alert_type=issue&environment=production&notification_uuid=26a6f6ae-a36d-4d21-99aa-fe62f8bd4056&project=4507222652813312&referrer=slack) sentry error.