### PR TITLE
MC-1677: adding disabled boolean field to Section DB model

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20250305203859_add_disabled_to_section/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20250305203859_add_disabled_to_section/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Section` ADD COLUMN `disabled` BOOLEAN NOT NULL DEFAULT false;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -115,6 +115,8 @@ model Section {
   sort                  Int?
   // we will not delete Sections, instead deactivate them
   active                Boolean         @default(false)
+  // disables/enables sections. can only be set via the admin tool
+  disabled              Boolean         @default(false)
   // track who created the Section
   createSource          ActivitySource // (ML or MANUAL) 
   // track who deactivated the Section


### PR DESCRIPTION
## Goal

We want curators to be able to disable/enable individual sections via the admin tool. Only enabled sections will be fed to Merino -> New Tab.

Adding new `disabled` `boolean` field to the Prisma `Section` DB model. 

- `false` by default
- can only be set via the admin tools.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1677
