### PR TITLE
MC-1679: adding disable & enable Section mutation

### DIFF
--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -78,6 +78,11 @@ export type CreateOrUpdateSectionApiInput = {
   active: boolean;
 };
 
+export type DisableEnableSectionApiInput = {
+  externalId: string;
+  disabled: boolean;
+};
+
 export type CreateSectionItemApiInput = {
   sectionExternalId: string;
   approvedItemExternalId: string;

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -556,6 +556,21 @@ input CreateOrUpdateSectionInput {
   active: Boolean!
 }
 
+"""
+Input data for disabling or enabling a Section
+"""
+input DisableEnableSectionInput {
+  """
+  An alternative primary key in UUID format supplied by ML.
+  """
+  externalId: ID!
+  """
+  Indicates whether or not a Section is fully disabled from display on NewTab. Can only  be controlled
+  in the admin tool.
+  """
+  disabled: Boolean!
+}
+
 extend type Section {
   """
   Indicates whether or not a Section is fully disabled from display on NewTab. Can only  be controlled
@@ -1263,6 +1278,11 @@ type Mutation {
   Removes an active SectionItem from a Section.
   """
   removeSectionItem(externalId: String!): SectionItem!
+
+  """
+  Disables or enables a Section. Can only be done from the admin tool.
+  """
+  disableEnableSection(data: DisableEnableSectionInput!): Section!
 }
 
 """

--- a/servers/curated-corpus-api/src/admin/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/index.ts
@@ -29,7 +29,7 @@ import {
 import { getOpenGraphFields } from './queries/OpenGraphFields';
 import { hasTrustedDomain } from './queries/ApprovedItem/hasTrustedDomain';
 import { getSectionsWithSectionItems } from './queries/Section';
-import { createOrUpdateSection } from './mutations/Section';
+import { createOrUpdateSection, disableEnableSection } from './mutations/Section';
 import { createSectionItem, removeSectionItem } from './mutations/SectionItem';
 
 export const resolvers = {
@@ -119,5 +119,6 @@ export const resolvers = {
     createOrUpdateSection: createOrUpdateSection,
     createSectionItem: createSectionItem,
     removeSectionItem: removeSectionItem,
+    disableEnableSection: disableEnableSection,
   },
 };

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/disableEnableSection.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/disableEnableSection.integration.ts
@@ -1,0 +1,175 @@
+import { print } from 'graphql';
+import request from 'supertest';
+
+import { ApolloServer } from '@apollo/server';
+import { PrismaClient, Section, SectionItem } from '.prisma/client';
+
+import {
+  ActivitySource,
+  DisableEnableSectionApiInput,
+  ScheduledSurfacesEnum,
+} from 'content-common';
+
+import { client } from '../../../../database/client';
+import { ApprovedItem } from '../../../../database/types';
+
+import {
+  clearDb,
+  createSectionHelper,
+  createSectionItemHelper,
+  createApprovedItemHelper,
+} from '../../../../test/helpers';
+
+import { DISABLE_ENABLE_SECTION } from '../sample-mutations.gql';
+import { MozillaAccessGroup } from 'content-common';
+import { startServer } from '../../../../express';
+import { IAdminContext } from '../../../context';
+
+describe('mutations: Section (disableEnableSection)', () => {
+  let app: Express.Application;
+  let db: PrismaClient;
+  let graphQLUrl: string;
+  let input: DisableEnableSectionApiInput;
+  let server: ApolloServer<IAdminContext>;
+  let activeEnabledSection: Section;
+  let activeDisabledSection: Section;
+  let sectionItem1: SectionItem;
+  let sectionItem2: SectionItem;
+  let approvedItem: ApprovedItem;
+
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, adminServer: server, adminUrl: graphQLUrl } = await startServer(0));
+    db = client();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await clearDb(db);
+    await db.$disconnect();
+  });
+
+  beforeEach(async () => {
+    // Approved item to create SectionItems
+    approvedItem = await createApprovedItemHelper(db, {
+      title: '10 Reasons You Should Quit Social Media',
+    });
+
+    // Create an active & enabled Section
+    activeEnabledSection = await createSectionHelper(db, {
+      externalId: 'active-123',
+      createSource: ActivitySource.ML,
+      scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
+      active: true
+    });
+
+    sectionItem1 = await createSectionItemHelper(db, {
+      approvedItemId: approvedItem.id,
+      sectionId: activeEnabledSection.id,
+      rank: 1,
+    });
+
+    // Create an active & disabled Section
+    activeDisabledSection = await createSectionHelper(db, {
+      externalId: 'active-disabled-123',
+      createSource: ActivitySource.ML,
+      scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
+      active: true,
+      disabled: true
+    });
+
+    sectionItem2 = await createSectionItemHelper(db, {
+      approvedItemId: approvedItem.id,
+      sectionId: activeDisabledSection.id,
+      rank: 1,
+    });
+  });
+
+  afterEach(async () => {
+    await clearDb(db);
+  });
+
+  it('should disable a Section successfully', async () => {
+    input = {
+      externalId: 'active-123',
+      disabled: true
+    };
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(DISABLE_ENABLE_SECTION),
+        variables: { data: input },
+      });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body.data).not.toBeNull();
+
+    // Expect Section to be disabled (disabled == true)
+    expect(result.body.data?.disableEnableSection.externalId).toEqual(
+      activeEnabledSection.externalId,
+    );
+    expect(result.body.data?.disableEnableSection.disabled).toBeTruthy();
+    // Expect the result to return the Section's SectionItem
+    expect(result.body.data?.disableEnableSection.sectionItems.length).toEqual(1);
+    expect(result.body.data?.disableEnableSection.sectionItems[0].externalId).toEqual(sectionItem1.externalId);
+  });
+
+  it('should enable a Section successfully', async () => {
+    input = {
+      externalId: 'active-disabled-123',
+      disabled: false
+    };
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(DISABLE_ENABLE_SECTION),
+        variables: { data: input },
+      });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body.data).not.toBeNull();
+
+    // Expect Section to be enabled (disabled == false)
+    expect(result.body.data?.disableEnableSection.externalId).toEqual(
+      activeDisabledSection.externalId,
+    );
+    expect(result.body.data?.disableEnableSection.disabled).toBeFalsy();
+    // Expect the result to return the Section's SectionItem
+    expect(result.body.data?.disableEnableSection.sectionItems.length).toEqual(1);
+    expect(result.body.data?.disableEnableSection.sectionItems[0].externalId).toEqual(sectionItem2.externalId);
+  });
+
+  it('should fail to enable/disable a Section if the Section does not exist', async () => {
+    input = {
+      externalId: 'fake-section',
+      disabled: true
+    };
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(DISABLE_ENABLE_SECTION),
+        variables: { data: input },
+      });
+
+    // we should have a NotFoundError
+    expect(result.body.errors).not.toBeUndefined();
+    expect(result.body.errors?.[0].extensions?.code).toEqual('NOT_FOUND');
+
+    // check the error message
+    expect(result.body.errors?.[0].message).toContain(
+      `Cannot disable or enable the section: Section with id "${input.externalId}" does not exist.`,
+    );
+  });
+});

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -101,6 +101,15 @@ export const CREATE_OR_UPDATE_SECTION = gql`
   ${AdminSectionData}
 `;
 
+export const DISABLE_ENABLE_SECTION = gql`
+    mutation disableEnableSection($data: DisableEnableSectionInput!) {
+        disableEnableSection(data: $data) {
+            ...AdminSectionData
+        }
+    }
+    ${AdminSectionData}
+`;
+
 export const CREATE_SECTION_ITEM = gql`
   mutation createSectionItem($data: CreateSectionItemInput!) {
     createSectionItem(data: $data) {

--- a/servers/curated-corpus-api/src/database/mutations/Section.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/Section.integration.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '.prisma/client';
 
 import { client } from '../client';
 import { clearDb, createApprovedItemHelper } from '../../test/helpers';
-import { createSection, updateSection } from './Section';
+import { createSection, disableEnableSection, updateSection } from './Section';
 import {
   createSectionHelper,
   createSectionItemHelper,
@@ -166,6 +166,41 @@ describe('Section', () => {
       expect(result.deactivateSource).toEqual(ActivitySource.ML);
       expect(result.deactivatedAt).toEqual(newDateMock);
       expect(result.sort).toEqual(3);
+    });
+  });
+
+  describe('disableEnableSection', () => {
+    it('should disable a Section', async () => {
+      await createSectionHelper(db, {
+        externalId: 'active-123',
+        title: 'New Title',
+      });
+
+      const input = {
+        externalId: 'active-123',
+        disabled: true
+      };
+
+      const result = await disableEnableSection(db, input);
+
+      expect(result.externalId).toEqual('active-123');
+      expect(result.disabled).toBeTruthy();
+    });
+    it('should enable a Section', async () => {
+      await createSectionHelper(db, {
+        externalId: 'active-890',
+        title: 'New Title',
+        disabled: true
+      });
+      const input = {
+        externalId: 'active-890',
+        disabled: false
+      };
+
+      const result = await disableEnableSection(db, input);
+
+      expect(result.externalId).toEqual('active-890');
+      expect(result.disabled).toBeFalsy();
     });
   });
 });

--- a/servers/curated-corpus-api/src/database/mutations/Section.ts
+++ b/servers/curated-corpus-api/src/database/mutations/Section.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, Prisma } from '.prisma/client';
-import { CreateSectionInput, Section } from '../types';
+import { CreateSectionInput, DisableEnableSectionInput, Section } from '../types';
 import { ActivitySource } from 'content-common';
 
 /**
@@ -8,6 +8,7 @@ import { ActivitySource } from 'content-common';
  * @param db
  * @param data
  * @param username
+ * @returns Section
  */
 export async function createSection(
   db: PrismaClient,
@@ -47,7 +48,7 @@ export async function createSection(
  * @param db
  * @param data
  * @param sectionId
- * @returns
+ * @returns Section
  */
 export async function updateSection(
   db: PrismaClient,
@@ -94,4 +95,43 @@ export async function updateSection(
     ...updatedSection,
     sectionItems: []
   }
+}
+
+/**
+ * This mutation disables or enables a Section.
+ *
+ * @param db
+ * @param data
+ * @returns Section
+ */
+export async function disableEnableSection(
+  db: PrismaClient,
+  data: DisableEnableSectionInput
+): Promise<Section> {
+  const { externalId, disabled } = data;
+
+  const updatedSectionData: Prisma.SectionUpdateInput = {
+    disabled,
+  };
+
+  return await db.section.update({
+    where: { externalId: externalId },
+    data: updatedSectionData,
+    include: {
+      sectionItems: {
+        where: {
+          active: true
+        },
+        include: {
+          approvedItem: {
+            include: {
+              authors: {
+                orderBy: [{ sortOrder: 'asc' }],
+              },
+            },
+          }
+        }
+      }
+    }
+  });
 }

--- a/servers/curated-corpus-api/src/database/mutations/index.ts
+++ b/servers/curated-corpus-api/src/database/mutations/index.ts
@@ -10,5 +10,5 @@ export {
   moveScheduledItemToBottom,
 } from './ScheduledItem';
 export { createScheduleReview } from './ScheduleReview';
-export { createSection, updateSection } from './Section';
+export { createSection, disableEnableSection, updateSection } from './Section';
 export { createSectionItem, removeSectionItem } from './SectionItem';

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -125,6 +125,11 @@ export type CreateSectionItemInput = {
   rank?: number;
 };
 
+export type DisableEnableSectionInput = {
+  externalId: string;
+  disabled: boolean;
+}
+
 export type ApprovedItem = ApprovedItemModel & {
   authors: ApprovedItemAuthor[];
 };


### PR DESCRIPTION
## Goal

Adding a dedicated admin api mutation `disableEnableSection` to disable or enable sections. This mutation is to be only used via the admin tool.

## Deployment step

- [ ] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1679
