### PR TITLE
[MC-1682] fix: capitalization after curly apostrophe

### DIFF
--- a/packages/content-common/src/index.spec.ts
+++ b/packages/content-common/src/index.spec.ts
@@ -119,6 +119,17 @@ describe('content-common', () => {
         expect(applyApTitleCase(swc.result)).toEqual(swc.expected);
       });
     });
+    it('should correctly format titles with curly apostrophes', () => {
+      const testCases = [
+        {
+          result: "every state\u2018S dream travel destination, mapped",
+          expected: "Every State\u2018s Dream Travel Destination, Mapped",
+        },
+      ];
+      testCases.forEach(({ result, expected }) => {
+        expect(applyApTitleCase(result)).toEqual(expected);
+      });
+    });
   });
   describe('lowercaseAfterApostrophe', () => {
     it('lowercase letter after apostrophe & return new string', () => {
@@ -130,6 +141,11 @@ describe('content-common', () => {
         "'Foo' foo'S DaY's You'Ll 'foo Bar foo'Ss'",
       );
       expect(result).toEqual("'Foo' foo's DaY's You'll 'foo Bar foo'ss'");
+    });
+    it('should lowercase the letter after a curly apostrophe', () => {
+      const input = "Every State\u2018S Dream Travel Destination, Mapped";
+      const expected = "Every State\u2018s Dream Travel Destination, Mapped";
+      expect(lowercaseAfterApostrophe(input)).toEqual(expected);
     });
   });
   // taken from curation admin tools

--- a/packages/content-common/src/index.ts
+++ b/packages/content-common/src/index.ts
@@ -54,13 +54,9 @@ export const sanitizeText = (input: string, maxLength: number): string => {
  * @returns {string}
  */
 export const lowercaseAfterApostrophe = (input: string): string => {
-  // matches an apostrophe followed by a char
-  // ensures only the first char after the apostrophe is converted to lowercase
-  const regex = /(?<=\w)(')(\w)/g;
-
-  return input.replace(regex, (match, p1, char) => {
-    return `'${char.toLowerCase()}`; // Lowercase the first char after the apostrophe
-  });
+  // Match either an ASCII or curly apostrophe followed by a letter, after a word character.
+  const regex = /(?<=\w)(['\u2018\u2019])(\w)/g;
+  return input.replace(regex, (_, apostrophe, letter) => `${apostrophe}${letter.toLowerCase()}`);
 };
 
 /**


### PR DESCRIPTION
## Goal
[MC-1682](https://mozilla-hub.atlassian.net/browse/MC-1682) Fix capitalization after an apostrophe [reported by editorial](https://mozilla.slack.com/archives/C05EVRU1U1X/p1741826855322319):

![image](https://github.com/user-attachments/assets/1fb503ff-4673-495c-9f1f-a6d95be43b76)

[MC-1682]: https://mozilla-hub.atlassian.net/browse/MC-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ