### PR TITLE
MC-1698: adding REST endpoint to admin corpus api for rejecting & unscheduling approved items for a domain

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
@@ -483,6 +483,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.body.data).not.toBeNull();
       expect(result.body.testing).toEqual(false);
       expect(result.body.domainName).toEqual('elpais.com');
+      expect(result.body.totalFoundApprovedCorpusItems).toEqual(2);
       expect(result.body.totalRejectedApprovedCorpusItems).toEqual(2);
     });
 

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
@@ -36,7 +36,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
   let server: ApolloServer<IAdminContext>;
   let graphQLUrl: string;
   let db: PrismaClient;
-  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-item-for-domain';
+  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-items-for-domain';
 
   beforeAll(async () => {
     // port 0 tells express to dynamically assign an available port

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
@@ -19,7 +19,7 @@ import {
 } from 'content-common';
 import { ACCESS_DENIED_ERROR } from '../../../../shared/types';
 import { MozillaAccessGroup } from 'content-common';
-import { clearDb, createApprovedItemHelper } from '../../../../test/helpers';
+import { clearDb, createApprovedItemHelper, createScheduledItemHelper } from '../../../../test/helpers';
 import {
   CREATE_APPROVED_ITEM,
   REJECT_APPROVED_ITEM,
@@ -36,6 +36,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
   let server: ApolloServer<IAdminContext>;
   let graphQLUrl: string;
   let db: PrismaClient;
+  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-item-for-domain';
 
   beforeAll(async () => {
     // port 0 tells express to dynamically assign an available port
@@ -47,6 +48,10 @@ describe('mutations: ApprovedItem - authentication checks', () => {
   afterAll(async () => {
     await server.stop();
     await db.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
   });
 
   // a standard set of inputs for this mutation
@@ -423,6 +428,115 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       expect(result.body.data).toBeNull();
       expect(result.body.errors).not.toBeUndefined();
       expect(result.body.errors?.[0].message).toContain(ACCESS_DENIED_ERROR);
+    });
+  });
+
+  describe('rejectApprovedCorpusItem mutation', () => {
+    it('should successfully reject and unschedule approved item for a domain when the user has full access', async () => {
+      // Set up auth headers with full access
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+      };
+
+      const item1 = await createApprovedItemHelper(db, {
+        title: '15 Unheard Ways To Achieve Greater Terraform',
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+        url: "https://elpais.com/example-one/"
+      });
+      // create a scheduled entry for item1
+      await createScheduledItemHelper(db, {
+        approvedItem: item1
+      });
+
+      const item2 = await createApprovedItemHelper(db, {
+        title: '16 Unheard Ways To Achieve Greater Terraform',
+        status: CuratedStatus.RECOMMENDATION,
+        language: 'EN',
+        url: "https://elpais.com/example-two/"
+      });
+      // create a scheduled entry for item2
+      await createScheduledItemHelper(db, {
+        approvedItem: item2
+      });
+
+      // expect 2 approved corpus items
+      let approvedCorpusItems = await db.approvedItem.findMany();
+      expect(approvedCorpusItems.length).toEqual(2);
+
+      // // expect 2 scheduled items
+      let scheduledItems = await db.scheduledItem.findMany();
+      expect(scheduledItems.length).toEqual(2);
+
+      // reject corpus items for elpais.com domain
+      // there are 2 approved corpus items & 2 scheduled items
+      const result = await request(app)
+        .post(rejectApprovedItemForDomainEndpoint)
+        .send({ domainName: 'elpais.com', testing: false })
+        .set(headers);
+
+      expect(result.status).toEqual(200);
+
+      expect(result.body.errors).toBeUndefined();
+      expect(result.body.data).not.toBeNull();
+      expect(result.body.testing).toEqual(false);
+      expect(result.body.domainName).toEqual('elpais.com');
+      expect(result.body.totalRejectedApprovedCorpusItems).toEqual(2);
+    });
+
+    it('should throw an error when the user has no access any scheduled surface', async () => {
+      // Set up auth headers without access to any Scheduled Surface
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2`,
+      };
+
+      const result = await request(app)
+        .post(rejectApprovedItemForDomainEndpoint)
+        .send({ domainName: 'elpais.com', testing: false })
+        .set(headers);
+
+      expect(result.error).not.toBeUndefined();
+      expect(result.body.data).toBeUndefined();
+
+      expect(result.error.text).toContain(ACCESS_DENIED_ERROR);
+    });
+
+    it('should throw an error when the user has only read-only access', async () => {
+      // Set up auth headers with read-only access
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,${MozillaAccessGroup.READONLY}`,
+      };
+
+      const result = await request(app)
+        .post(rejectApprovedItemForDomainEndpoint)
+        .send({ domainName: 'elpais.com', testing: false })
+        .set(headers);
+
+      expect(result.error).not.toBeUndefined();
+      expect(result.body.data).toBeUndefined();
+
+      expect(result.error.text).toContain(ACCESS_DENIED_ERROR);
+    });
+
+    it('should throw an error when the request headers are undefined', async () => {
+      // pass in empty object for headers
+      const headers = {};
+
+      const result = await request(app)
+        .post(rejectApprovedItemForDomainEndpoint)
+        .send({ domainName: 'elpais.com', testing: false })
+        .set(headers);
+
+      expect(result.error).not.toBeUndefined();
+      expect(result.body.data).toBeUndefined();
+
+      expect(result.error.text).toContain(ACCESS_DENIED_ERROR);
     });
   });
 });

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -326,6 +326,7 @@ export async function rejectApprovedCorpusItemsForDomain(
   testing: boolean,
   context: IAdminContext,
 ): Promise<number> {
+  console.log('rejectApprovedCorpusItemsForDomain, context.authenticatedUser: ', context.authenticatedUser)
   // Check if the user can execute this endpoint
   if (!context.authenticatedUser.canWriteToCorpus()) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -345,7 +345,7 @@ export async function rejectApprovedCorpusItemsForDomain(
 
       // 3. Unschedule all scheduled items
       for (const scheduledItem of scheduledItems) {
-        await deleteScheduledItem(null, { data: { externalId: scheduledItem.externalId } }, context);
+        await deleteScheduledItem(null, { data: { externalId: scheduledItem.externalId, actionScreen: ActionScreen.CORPUS } }, context);
       }
 
       // 4. Construct input for rejecting approvied Item

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -2,8 +2,7 @@ import {
   AuthenticationError,
   UserInputError,
 } from '@pocket-tools/apollo-utils';
-
-import { Topics } from 'content-common';
+import { ActionScreen, Topics } from 'content-common';
 
 import {
   createApprovedItem as dbCreateApprovedItem,
@@ -12,7 +11,7 @@ import {
   deleteApprovedItem as dbDeleteApprovedItem,
   updateApprovedItem as dbUpdateApprovedItem,
 } from '../../../../database/mutations';
-import { getApprovedItemByExternalId } from '../../../../database/queries';
+import { getApprovedItemByExternalId, getApprovedItemsForDomain } from '../../../../database/queries';
 import {
   ApprovedCorpusItemPayload,
   RejectedCorpusItemPayload,
@@ -34,6 +33,10 @@ import {
 } from '../../../../database/types';
 import { IAdminContext } from '../../../context';
 import { createTrustedDomainIfPastScheduledDateExists } from '../../../../database/mutations/TrustedDomain';
+import {
+  getScheduledItemsForApprovedCorpusItem,
+} from '../../../../database/queries/ScheduledItem';
+import { deleteScheduledItem } from '../ScheduledItem';
 
 /**
  * Creates an approved curated item with data supplied. Optionally, schedules the freshly
@@ -305,6 +308,63 @@ export async function rejectApprovedItem(
   approvedItem.updatedBy = context.authenticatedUser.username;
 
   return approvedItem;
+}
+
+/**
+ * Finds all ApprovedCorpusItems for a give domain name.
+ * Finds all ScheduledItems for ApprovedCorpus Items & unschedules the items.
+ * Rejects all found ApprovedCorpus Items.
+ *
+ * @param parent
+ * @param domainName
+ * @param testing
+ * @param context
+ */
+export async function rejectApprovedCorpusItemsForDomain(
+  parent,
+  domainName: string,
+  testing: boolean,
+  context: IAdminContext,
+): Promise<number> {
+  // Check if the user can execute this endpoint
+  if (!context.authenticatedUser.canWriteToCorpus()) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+  // 1. Get approved corpus items for a domain name
+  const approvedItems = await getApprovedItemsForDomain(context.db, domainName);
+  if (testing ) {
+    return approvedItems.length;
+  }
+  const rejectedItemExternalIds: (string | null)[] = [];
+
+  for (const approvedItem of approvedItems) {
+    try {
+      // 2. Get scheduled items
+      const scheduledItems = await getScheduledItemsForApprovedCorpusItem(context.db, approvedItem.id);
+
+      // 3. Unschedule all scheduled items
+      for (const scheduledItem of scheduledItems) {
+        await deleteScheduledItem(null, { data: { externalId: scheduledItem.externalId } }, context);
+      }
+
+      // 4. Construct input for rejecting approvied Item
+      const rejectApprovedItemInput = {
+        externalId: approvedItem.externalId,
+        reason: "PUBLISHER_REQUEST",
+        actionScreen: ActionScreen.CORPUS,
+      };
+
+      // 5. Reject approved item
+      const rejectedItem = await rejectApprovedItem(null, { data: rejectApprovedItemInput }, context);
+      rejectedItemExternalIds.push(rejectedItem?.externalId || null);
+    } catch (error) {
+      console.error(`Error processing ApprovedCorpusItem ${approvedItem.id}:`, error);
+      // Silently continue even if error
+      rejectedItemExternalIds.push(null);
+    }
+  }
+  // Remove all "falsy" (null in this case) values
+  return rejectedItemExternalIds.filter(Boolean).length;
 }
 
 /**

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -37,6 +37,7 @@ import {
   getScheduledItemsForApprovedCorpusItem,
 } from '../../../../database/queries/ScheduledItem';
 import { deleteScheduledItem } from '../ScheduledItem';
+import { RejectApprovedCorpusItemsForDomainResponse } from '../../types';
 
 /**
  * Creates an approved curated item with data supplied. Optionally, schedules the freshly
@@ -325,8 +326,7 @@ export async function rejectApprovedCorpusItemsForDomain(
   domainName: string,
   testing: boolean,
   context: IAdminContext,
-): Promise<number> {
-  console.log('rejectApprovedCorpusItemsForDomain, context.authenticatedUser: ', context.authenticatedUser)
+): Promise<RejectApprovedCorpusItemsForDomainResponse> {
   // Check if the user can execute this endpoint
   if (!context.authenticatedUser.canWriteToCorpus()) {
     throw new AuthenticationError(ACCESS_DENIED_ERROR);
@@ -334,7 +334,7 @@ export async function rejectApprovedCorpusItemsForDomain(
   // 1. Get approved corpus items for a domain name
   const approvedItems = await getApprovedItemsForDomain(context.db, domainName);
   if (testing ) {
-    return approvedItems.length;
+    return { totalFoundApprovedCorpusItems: approvedItems.length };
   }
   const rejectedItemExternalIds: (string | null)[] = [];
 
@@ -365,7 +365,11 @@ export async function rejectApprovedCorpusItemsForDomain(
     }
   }
   // Remove all "falsy" (null in this case) values
-  return rejectedItemExternalIds.filter(Boolean).length;
+  const rejectedItemsCount = rejectedItemExternalIds.filter(Boolean).length;
+  return {
+    totalFoundApprovedCorpusItems: approvedItems.length,
+    totalRejectedApprovedCorpusItems: rejectedItemsCount
+  }
 }
 
 /**

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -67,7 +67,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
       title: '16 Unheard Ways To Achieve Greater Terraform',
       status: CuratedStatus.RECOMMENDATION,
       language: 'EN',
-      url: "https://elpais.com/example-two/"
+      url: "http://www.elpais.com/example-two/"
     });
     // create a scheduled entry for item2
     await createScheduledItemHelper(db, {

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -22,7 +22,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
   let app: Express.Application;
   let server: ApolloServer<IAdminContext>;
   let db: PrismaClient;
-  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-item-for-domain';
+  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-items-for-domain';
 
   beforeAll(async () => {
     // port 0 tells express to dynamically assign an available port

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -46,7 +46,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     await clearDb(db);
   });
 
-  it('should reject all approved corpus items & unschedule items for a domain & return totalRejectedApprovedCorpusItems count when testing=false', async () => {
+  it('should reject all approved corpus items & unschedule items for a domain & return totalFoundApprovedCorpusItems & totalRejectedApprovedCorpusItems count when testing=false', async () => {
     // Set up event tracking
     const eventTracker = jest.fn();
     eventEmitter.on(ReviewedCorpusItemEventType.REMOVE_ITEM, eventTracker);
@@ -104,6 +104,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     expect(res.body.testing).toEqual(false);
     expect(res.body.domainName).toEqual('elpais.com');
     expect(res.body.totalRejectedApprovedCorpusItems).toEqual(2);
+    expect(res.body.totalFoundApprovedCorpusItems).toEqual(2);
 
     // There should now be only 1 approved corpous item & 1 scheduled item
     // in db for other.domain.com
@@ -182,6 +183,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
       .set(headers);
 
     expect(res.status).toEqual(200);
+    expect(res.body.totalFoundApprovedCorpusItems).toEqual(0);
     expect(res.body.totalRejectedApprovedCorpusItems).toEqual(0);
   });
 });

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -1,0 +1,187 @@
+import request from 'supertest';
+
+import { ApolloServer } from '@apollo/server';
+import { PrismaClient } from '.prisma/client';
+
+import { CuratedStatus } from 'content-common';
+
+import { client } from '../../../../database/client';
+
+import {
+  clearDb,
+  createApprovedItemHelper,
+  createScheduledItemHelper,
+} from '../../../../test/helpers';
+import { curatedCorpusEventEmitter as eventEmitter } from '../../../../events/init';
+import { ReviewedCorpusItemEventType } from '../../../../events/types';
+import { MozillaAccessGroup } from 'content-common';
+import { startServer } from '../../../../express';
+import { IAdminContext } from '../../../context';
+
+describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IAdminContext>;
+  let db: PrismaClient;
+  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-item-for-domain';
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, adminServer: server } = await startServer(0));
+    db = client();
+    await clearDb(db);
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await db.$disconnect();
+  });
+
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+
+  beforeEach(async () => {
+    await clearDb(db);
+  });
+
+  it('should reject all approved corpus items & unschedule items for a domain & return totalRejectedApprovedCorpusItems count when testing=false', async () => {
+    // Set up event tracking
+    const eventTracker = jest.fn();
+    eventEmitter.on(ReviewedCorpusItemEventType.REMOVE_ITEM, eventTracker);
+    eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
+
+    const item1 = await createApprovedItemHelper(db, {
+      title: '15 Unheard Ways To Achieve Greater Terraform',
+      status: CuratedStatus.RECOMMENDATION,
+      language: 'EN',
+      url: "https://elpais.com/example-one/"
+    });
+    // create a scheduled entry for item1
+    await createScheduledItemHelper(db, {
+      approvedItem: item1
+    });
+
+    const item2 = await createApprovedItemHelper(db, {
+      title: '16 Unheard Ways To Achieve Greater Terraform',
+      status: CuratedStatus.RECOMMENDATION,
+      language: 'EN',
+      url: "https://elpais.com/example-two/"
+    });
+    // create a scheduled entry for item2
+    await createScheduledItemHelper(db, {
+      approvedItem: item2
+    });
+
+    const item3 = await createApprovedItemHelper(db, {
+      title: 'Another item',
+      status: CuratedStatus.RECOMMENDATION,
+      language: 'EN',
+      url: "https://other.domain.com/example-one/"
+    });
+    // create a scheduled entry for item3
+    const scheduledItem3 = await createScheduledItemHelper(db, {
+      approvedItem: item3
+    });
+
+    // expect 3 approved corpus items
+    let approvedCorpusItems = await db.approvedItem.findMany();
+    expect(approvedCorpusItems.length).toEqual(3);
+
+    // // expect 3 scheduled items
+    let scheduledItems = await db.scheduledItem.findMany();
+    expect(scheduledItems.length).toEqual(3);
+
+    // reject corpus items for elpais.com domain
+    // there are 2 approved corpus items & 2 scheduled items
+    const res = await request(app)
+      .post(rejectApprovedItemForDomainEndpoint)
+      .send({ domainName: 'elpais.com', testing: false })
+      .set(headers);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.testing).toEqual(false);
+    expect(res.body.domainName).toEqual('elpais.com');
+    expect(res.body.totalRejectedApprovedCorpusItems).toEqual(2);
+
+    // There should now be only 1 approved corpous item & 1 scheduled item
+    // in db for other.domain.com
+    approvedCorpusItems = await db.approvedItem.findMany();
+    expect(approvedCorpusItems.length).toEqual(1);
+    expect(approvedCorpusItems[0].url).toEqual(item3.url)
+
+    scheduledItems = await db.scheduledItem.findMany();
+    expect(scheduledItems.length).toEqual(1);
+    expect(scheduledItems[0].externalId).toEqual(scheduledItem3.externalId);
+
+    // Check that there are 4 events sent to Snowplow
+    // 2 REMOVE_ITEM events (for removing scheduled item)
+    // 2 REJECT_ITEM events (for rejecting the 2 corpus items)
+    // Check that the REMOVE_ITEM and REJECT_ITEM events were fired successfully.
+    expect(eventTracker).toHaveBeenCalledTimes(4);
+    const removeItemEvent1 = await eventTracker.mock.calls[0][0];
+    const rejectItemEvent1 = await eventTracker.mock.calls[1][0];
+    const removeItemEvent2 = await eventTracker.mock.calls[2][0];
+    const rejectItemEvent2 = await eventTracker.mock.calls[3][0];
+
+    expect(removeItemEvent1.eventType).toEqual(
+      ReviewedCorpusItemEventType.REMOVE_ITEM,
+    );
+    expect(rejectItemEvent1.eventType).toEqual(
+      ReviewedCorpusItemEventType.REJECT_ITEM,
+    );
+
+    expect(removeItemEvent2.eventType).toEqual(
+      ReviewedCorpusItemEventType.REMOVE_ITEM,
+    );
+    expect(rejectItemEvent2.eventType).toEqual(
+      ReviewedCorpusItemEventType.REJECT_ITEM,
+    );
+  });
+
+  it('should return totalFoundApprovedCorpusItems count but not unschedule or reject items when testing=true', async () => {
+    // create approved corpus item
+    const item = await createApprovedItemHelper(db, {
+      title: '15 Unheard Ways To Achieve Greater Terraform',
+      status: CuratedStatus.RECOMMENDATION,
+      language: 'EN',
+      url: "https://elpais.com/example-one/"
+    });
+
+    // create a scheduled entry
+    await createScheduledItemHelper(db, {
+      approvedItem: item
+    });
+
+    const res = await request(app)
+      .post(rejectApprovedItemForDomainEndpoint)
+      .send({ domainName: 'elpais.com', testing: true })
+      .set(headers);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.testing).toEqual(true);
+    expect(res.body.domainName).toEqual('elpais.com');
+    expect(res.body.totalFoundApprovedCorpusItems).toEqual(1);
+    // items should not be reject/unscheduled
+    expect(res.body.totalRejectedApprovedCorpusItems).toBeUndefined();
+
+    // The approved item should still exist in db
+    const approvedCorpusItems = await db.approvedItem.findMany();
+    expect(approvedCorpusItems.length).toEqual(1);
+
+    // The scheduled item should still exist in db
+    const scheduledItems = await db.scheduledItem.findMany();
+    expect(scheduledItems.length).toEqual(1);
+  });
+
+  it('should return 0 when no approved corpus items found for the domain', async () => {
+    const res = await request(app)
+      .post(rejectApprovedItemForDomainEndpoint)
+      .send({ domainName: 'nonexistent.com', testing: false })
+      .set(headers);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.totalRejectedApprovedCorpusItems).toEqual(0);
+  });
+});

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -13,7 +13,7 @@ import {
   createScheduledItemHelper,
 } from '../../../../test/helpers';
 import { curatedCorpusEventEmitter as eventEmitter } from '../../../../events/init';
-import { ReviewedCorpusItemEventType } from '../../../../events/types';
+import { ReviewedCorpusItemEventType, ScheduledCorpusItemEventType } from '../../../../events/types';
 import { MozillaAccessGroup } from 'content-common';
 import { startServer } from '../../../../express';
 import { IAdminContext } from '../../../context';
@@ -52,6 +52,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     const eventTracker = jest.fn();
     eventEmitter.on(ReviewedCorpusItemEventType.REMOVE_ITEM, eventTracker);
     eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
+    eventEmitter.on(ScheduledCorpusItemEventType.REMOVE_SCHEDULE, eventTracker);
 
     const item1 = await createApprovedItemHelper(db, {
       title: '15 Unheard Ways To Achieve Greater Terraform',
@@ -117,16 +118,23 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     expect(scheduledItems.length).toEqual(1);
     expect(scheduledItems[0].externalId).toEqual(scheduledItem3.externalId);
 
-    // Check that there are 4 events sent to Snowplow
-    // 2 REMOVE_ITEM events (for removing scheduled item)
+    // Check that there are 6 events sent to Snowplow
+    // 2 REMOVE_SCHEDULE events (for deleting scheduled item)
+    // 2 REMOVE_ITEM events (for removing corpus items from ApprovedCorpus)
     // 2 REJECT_ITEM events (for rejecting the 2 corpus items)
-    // Check that the REMOVE_ITEM and REJECT_ITEM events were fired successfully.
-    expect(eventTracker).toHaveBeenCalledTimes(4);
-    const removeItemEvent1 = await eventTracker.mock.calls[0][0];
-    const rejectItemEvent1 = await eventTracker.mock.calls[1][0];
-    const removeItemEvent2 = await eventTracker.mock.calls[2][0];
-    const rejectItemEvent2 = await eventTracker.mock.calls[3][0];
+    // Check that the REMOVE_ITEM, REJECT_ITEM, REMOVE_SCHEDULE events were fired successfully.
+    expect(eventTracker).toHaveBeenCalledTimes(6);
+    const removeScheduledItemEvent1 = await eventTracker.mock.calls[0][0];
+    const removeItemEvent1 = await eventTracker.mock.calls[1][0];
+    const rejectItemEvent1 = await eventTracker.mock.calls[2][0];
 
+    const removeScheduledItemEvent2 = await eventTracker.mock.calls[3][0];
+    const removeItemEvent2 = await eventTracker.mock.calls[4][0];
+    const rejectItemEvent2 = await eventTracker.mock.calls[5][0];
+
+    expect(removeScheduledItemEvent1.eventType).toEqual(
+      ScheduledCorpusItemEventType.REMOVE_SCHEDULE,
+    );
     expect(removeItemEvent1.eventType).toEqual(
       ReviewedCorpusItemEventType.REMOVE_ITEM,
     );
@@ -134,6 +142,9 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
       ReviewedCorpusItemEventType.REJECT_ITEM,
     );
 
+    expect(removeScheduledItemEvent2.eventType).toEqual(
+      ScheduledCorpusItemEventType.REMOVE_SCHEDULE,
+    );
     expect(removeItemEvent2.eventType).toEqual(
       ReviewedCorpusItemEventType.REMOVE_ITEM,
     );
@@ -149,6 +160,7 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     const eventTracker = jest.fn();
     eventEmitter.on(ReviewedCorpusItemEventType.REMOVE_ITEM, eventTracker);
     eventEmitter.on(ReviewedCorpusItemEventType.REJECT_ITEM, eventTracker);
+    eventEmitter.on(ScheduledCorpusItemEventType.REMOVE_SCHEDULE, eventTracker);
 
     const item1 = await createApprovedItemHelper(db, {
       title: '15 Unheard Ways To Achieve Greater Terraform',
@@ -216,14 +228,19 @@ describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
     expect(scheduledItems[0].externalId).toEqual(scheduledItem2.externalId);
     expect(scheduledItems[1].externalId).toEqual(scheduledItem3.externalId);
 
-    // Check that there are 2 events sent to Snowplow
-    // 1 REMOVE_ITEM event1 (for removing scheduled item)
+    // Check that there are 3 events sent to Snowplow
+    // 1 REMOVE_SCHEDULE event (for deleting scheduled item)
+    // 1 REMOVE_ITEM event (for removing corpus item from ApprovedCorpus)
     // 1 REJECT_ITEM event (for rejecting the corpus items)
-    // Check that the REMOVE_ITEM and REJECT_ITEM events were fired successfully.
-    expect(eventTracker).toHaveBeenCalledTimes(2);
-    const removeItemEvent1 = await eventTracker.mock.calls[0][0];
-    const rejectItemEvent1 = await eventTracker.mock.calls[1][0];
+    // Check that the REMOVE_ITEM, REJECT_ITEM, REMOVE_SCHEDULE events were fired successfully.
+    expect(eventTracker).toHaveBeenCalledTimes(3);
+    const removeScheduledItemEvent1 = await eventTracker.mock.calls[0][0];
+    const removeItemEvent1 = await eventTracker.mock.calls[1][0];
+    const rejectItemEvent1 = await eventTracker.mock.calls[2][0];
 
+    expect(removeScheduledItemEvent1.eventType).toEqual(
+      ScheduledCorpusItemEventType.REMOVE_SCHEDULE,
+    );
     expect(removeItemEvent1.eventType).toEqual(
       ReviewedCorpusItemEventType.REMOVE_ITEM,
     );

--- a/servers/curated-corpus-api/src/admin/resolvers/types.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/types.ts
@@ -60,3 +60,8 @@ export type CreateScheduleReviewInput = {
   scheduledSurfaceGuid: string;
   scheduledDate: string;
 };
+
+export type RejectApprovedCorpusItemsForDomainResponse = {
+  totalFoundApprovedCorpusItems: number;
+  totalRejectedApprovedCorpusItems?: number;
+}

--- a/servers/curated-corpus-api/src/admin/routes/admin.ts
+++ b/servers/curated-corpus-api/src/admin/routes/admin.ts
@@ -9,21 +9,19 @@ adminRouter.post('/reject-approved-corpus-items-for-domain', async (req, res) =>
   const { domainName, testing } = req.body;
   // get the admin context
   const context = await getAdminContext({ req });
-  console.log('reject-approved-corpus-items-for-domain context: ', context);
 
   if (!domainName) {
     return res.status(400).json({ error: 'Missing domainName query param' });
   }
 
   try {
-    const result = await rejectApprovedCorpusItemsForDomain(null, domainName, testing, context);
+    const { totalFoundApprovedCorpusItems, totalRejectedApprovedCorpusItems } = await rejectApprovedCorpusItemsForDomain(null, domainName, testing, context);
 
     return res.json({
       testing,
       domainName,
-      ...(testing
-        ? { totalFoundApprovedCorpusItems: result } // do not reject/unschedule if testing=true
-        : { totalRejectedApprovedCorpusItems: result }),
+      totalFoundApprovedCorpusItems: totalFoundApprovedCorpusItems,
+      totalRejectedApprovedCorpusItems: testing ? undefined : totalRejectedApprovedCorpusItems,
     });
   } catch (e) {
     console.error('Error rejecting approved corpus items:', e);

--- a/servers/curated-corpus-api/src/admin/routes/admin.ts
+++ b/servers/curated-corpus-api/src/admin/routes/admin.ts
@@ -4,8 +4,8 @@ import { rejectApprovedCorpusItemsForDomain } from '../resolvers/mutations/Appro
 
 const adminRouter = Router();
 
-// expose admin REST endpoint reject-approved-corpus-item-for-domain
-adminRouter.post('/reject-approved-corpus-item-for-domain', async (req, res) => {
+// expose admin REST endpoint reject-approved-corpus-items-for-domain
+adminRouter.post('/reject-approved-corpus-items-for-domain', async (req, res) => {
   const { domainName, testing } = req.body;
   // get the admin context
   const context = await getAdminContext({ req });

--- a/servers/curated-corpus-api/src/admin/routes/admin.ts
+++ b/servers/curated-corpus-api/src/admin/routes/admin.ts
@@ -1,0 +1,33 @@
+import { Router } from 'express';
+import { getAdminContext } from '../context';
+import { rejectApprovedCorpusItemsForDomain } from '../resolvers/mutations/ApprovedItem';
+
+const adminRouter = Router();
+
+// expose admin REST endpoint reject-approved-corpus-item-for-domain
+adminRouter.post('/reject-approved-corpus-item-for-domain', async (req, res) => {
+  const { domainName, testing } = req.body;
+  // get the admin context
+  const context = await getAdminContext({ req });
+
+  if (!domainName) {
+    return res.status(400).json({ error: 'Missing domainName query param' });
+  }
+
+  try {
+    const result = await rejectApprovedCorpusItemsForDomain(null, domainName, testing, context);
+
+    return res.json({
+      testing,
+      domainName,
+      ...(testing
+        ? { totalFoundApprovedCorpusItems: result } // do not reject/unschedule if testing=true
+        : { totalRejectedApprovedCorpusItems: result }),
+    });
+  } catch (e) {
+    console.error('Error rejecting approved corpus items:', e);
+    res.status(500).send(`fail: ${e}`);
+  }
+});
+
+export default adminRouter;

--- a/servers/curated-corpus-api/src/admin/routes/admin.ts
+++ b/servers/curated-corpus-api/src/admin/routes/admin.ts
@@ -9,6 +9,7 @@ adminRouter.post('/reject-approved-corpus-items-for-domain', async (req, res) =>
   const { domainName, testing } = req.body;
   // get the admin context
   const context = await getAdminContext({ req });
+  console.log('reject-approved-corpus-items-for-domain context: ', context);
 
   if (!domainName) {
     return res.status(400).json({ error: 'Missing domainName query param' });

--- a/servers/curated-corpus-api/src/database/queries/ApprovedItem.ts
+++ b/servers/curated-corpus-api/src/database/queries/ApprovedItem.ts
@@ -29,6 +29,26 @@ type ApprovedItemCursor = {
 };
 
 /**
+ * Return ApprovedItems for a given domain name.
+ *
+ * @param db
+ * @param domainName
+ */
+export async function getApprovedItemsForDomain(
+  db: PrismaClient,
+  domainName: string
+): Promise<ApprovedItem[]> {
+  return db.approvedItem.findMany({
+    where: {url: { contains: domainName }},
+    include: {
+      authors: {
+        orderBy: [{ sortOrder: 'asc' }],
+      },
+    },
+  });
+}
+
+/**
  * Return a Relay-style paginated, optionally filtered list of approved items.
  *
  * @param db

--- a/servers/curated-corpus-api/src/database/queries/ApprovedItem.ts
+++ b/servers/curated-corpus-api/src/database/queries/ApprovedItem.ts
@@ -39,7 +39,14 @@ export async function getApprovedItemsForDomain(
   domainName: string
 ): Promise<ApprovedItem[]> {
   return db.approvedItem.findMany({
-    where: {url: { contains: domainName }},
+    where: {
+      OR: [
+        { url: { startsWith: `https://${domainName}` } },
+        { url: { startsWith: `http://${domainName}` } },
+        { url: { startsWith: `https://www.${domainName}` } },
+        { url: { startsWith: `http://www.${domainName}` } },
+      ],
+    },
     include: {
       authors: {
         orderBy: [{ sortOrder: 'asc' }],

--- a/servers/curated-corpus-api/src/database/queries/ScheduledItem.ts
+++ b/servers/curated-corpus-api/src/database/queries/ScheduledItem.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '.prisma/client';
 import { DateTime } from 'luxon';
+import { ScheduledItem as ScheduledItemPrisma } from '.prisma/client';
 import {
   ScheduledItem,
   ScheduledItemFilterInput,
@@ -13,7 +14,23 @@ import {
 import { groupBy } from '../../shared/utils';
 import { UserInputError } from '@pocket-tools/apollo-utils';
 
+
 /**
+ * Gets a list of scheduled items for an ApprovedCorpusItem
+ * @param db
+ * @param approvedCorpusId
+ */
+export async function getScheduledItemsForApprovedCorpusItem(
+  db: PrismaClient,
+  approvedCorpusId: number
+): Promise<ScheduledItemPrisma[]> {
+  return await db.scheduledItem.findMany({
+    where: {approvedItemId: approvedCorpusId}
+  });
+}
+
+/**
+ * Gets a list of scheduled items based on filters.
  * @param db
  * @param filters
  */

--- a/servers/curated-corpus-api/src/database/queries/index.ts
+++ b/servers/curated-corpus-api/src/database/queries/index.ts
@@ -1,5 +1,6 @@
 export {
   getApprovedItems,
+  getApprovedItemsForDomain,
   getApprovedItemByUrl,
   getApprovedItemByExternalId,
   getScheduledSurfaceHistory,

--- a/servers/curated-corpus-api/src/express.ts
+++ b/servers/curated-corpus-api/src/express.ts
@@ -17,6 +17,7 @@ import { getAdminContext, IAdminContext } from './admin/context';
 import { getPublicContext, IPublicContext } from './public/context';
 import { startAdminServer } from './admin/server';
 import { startPublicServer } from './public/server';
+import adminRouter from './admin/routes/admin';
 
 export async function startServer(port: number): Promise<{
   app: Express.Application;
@@ -59,6 +60,9 @@ export async function startServer(port: number): Promise<{
   // set up admin server
   const adminServer = await startAdminServer(httpServer);
   const adminUrl = '/admin';
+
+  // Mount the custom admin REST router first
+  app.use(adminUrl, adminRouter);
 
   app.use(
     adminUrl,


### PR DESCRIPTION
## Goal

There has been a request to delete several approved corpus items and all related scheduled items for a domain.

Added a POST REST endpoint to the admin curated corpus api: `/admin/reject-approved-corpus-items-for-domain`:
    * takes in two params: `domainName` & `testing`
    * if `testing`=`false`, approved items for the domain are rejected/unscheduled
    * if `testing`=`true`, the count of approved items found for the domain is returned
    * Example request body:
    ```
     {
	"domainName": "elpais.com",
	"testing": false
     } 
     ```

* Added the new REST endpoint in `admin/routes`
* Created a new function/mutation `rejectApprovedCorpusItemsForDomain` which takes in a `domainName` &:
    * finds all approved items for the domain
    * finds all scheduled items for the approved item
        * unschedules each item
    * rejects the approved corpus items

User must have FULL access to execute this endpoint.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1698
