### PR TITLE
MC-1699: remove REST endpoint /admin/reject-approved-corpus-items-for-domain

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
@@ -431,7 +431,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
     });
   });
 
-  describe('rejectApprovedCorpusItem mutation', () => {
+  describe.skip('rejectApprovedCorpusItemsForDomain mutation', () => {
     it('should successfully reject and unschedule approved item for a domain when the user has full access', async () => {
       // Set up auth headers with full access
       const headers = {

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/rejectApprovedCorpusItemsForDomain.integration.ts
@@ -18,7 +18,7 @@ import { MozillaAccessGroup } from 'content-common';
 import { startServer } from '../../../../express';
 import { IAdminContext } from '../../../context';
 
-describe('mutations: ApprovedItem (rejectApprovedCorpusItem)', () => {
+describe.skip('mutations: ApprovedItem (rejectApprovedCorpusItemsForDomain)', () => {
   let app: Express.Application;
   let server: ApolloServer<IAdminContext>;
   let db: PrismaClient;

--- a/servers/curated-corpus-api/src/express.ts
+++ b/servers/curated-corpus-api/src/express.ts
@@ -17,7 +17,8 @@ import { getAdminContext, IAdminContext } from './admin/context';
 import { getPublicContext, IPublicContext } from './public/context';
 import { startAdminServer } from './admin/server';
 import { startPublicServer } from './public/server';
-import adminRouter from './admin/routes/admin';
+// Uncomment to expose the admin router where admin REST endpoints live
+// import adminRouter from './admin/routes/admin';
 
 export async function startServer(port: number): Promise<{
   app: Express.Application;
@@ -61,8 +62,10 @@ export async function startServer(port: number): Promise<{
   const adminServer = await startAdminServer(httpServer);
   const adminUrl = '/admin';
 
+  // Endpoint created for https://mozilla-hub.atlassian.net/browse/MC-1698
+  // Uncomment if endpoint needs to be mounted & deployed
   // Mount the custom admin REST router first
-  app.use(adminUrl, adminRouter);
+  // app.use(adminUrl, adminRouter);
 
   app.use(
     adminUrl,


### PR DESCRIPTION
## Goal

Removing the corpus API REST endpoint `/admin/reject-approved-corpus-items-for-domain`.
Keeping the code but unmounting from the admin server. Skipping tests covering this endpoint.
Endpoint can be un-commented and re-deployed in the future if there is a use-case.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1699