### PR TITLE
fix: try to get JWT_KEY env var into AWS infra

### DIFF
--- a/infrastructure/section-manager-lambda/src/sectionManagerLambda.ts
+++ b/infrastructure/section-manager-lambda/src/sectionManagerLambda.ts
@@ -65,7 +65,10 @@ export class SectionManagerSQSLambda extends Construct {
           //
           // this PR may provide some context:
           // https://github.com/Pocket/pocket-monorepo/pull/324
-          ignoreEnvironmentVars: ['GIT_SHA'],
+
+          // removing this directive as it may be why JWT_KEY above was never
+          // added to the ENV vars in AWS
+          //ignoreEnvironmentVars: ['GIT_SHA'],
           vpcConfig: {
             securityGroupIds: this.vpc.defaultSecurityGroups.ids,
             subnetIds: this.vpc.privateSubnetIds,


### PR DESCRIPTION
## Goal

the `JWT_KEY` env var somehow never got added to prod (it does exist in dev). unclear why a deployment did not add this env var. trying removing a semi-mysterious infra config line to see if it solves the problem.

- comment out `ignoreEnvironmentVars: ['GIT_SHA']` in section manager lambda infra code 

## I'd love feedback/perspectives on:

- any other guesses as to why `JWT_KEY` never made it to prod?