### PR TITLE
test: add test env var to section mgr lambda to debug missing env var

### DIFF
--- a/infrastructure/section-manager-lambda/src/sectionManagerLambda.ts
+++ b/infrastructure/section-manager-lambda/src/sectionManagerLambda.ts
@@ -49,6 +49,7 @@ export class SectionManagerSQSLambda extends Construct {
             NODE_ENV: environment,
             REGION: this.vpc.region,
             SENTRY_DSN: this.getSentryDsn(),
+            TEST: 'test',
           },
           // why do we have `ignoreEnvironmentVars`?
           // 2025-01-15


### PR DESCRIPTION
## Goal

the pre-existing `JWT_KEY` env var (line 48 in the file changed) was never created in prod. adding a test env var here to see if it gets the missing env var created.

- add test env var to section manager lambda

## Implementation Decisions

- this was the best way i could think of to force a re-deployment of the section manager lambda infra that should result in env vars being updated.

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/MC-1700