### PR TITLE
HNT-500: update removeSectionItem mutation to store deactivateReasons

### DIFF
--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -55,6 +55,21 @@ export enum ActionScreen {
   SECTIONS = 'SECTIONS',
 }
 
+export enum SectionItemRemovalReason {
+  ARTICLE_QUALITY = 'ARTICLE_QUALITY',
+  CONTROVERSIAL = 'CONTROVERSIAL',
+  DATED = 'DATED',
+  HED_DEK_QUALITY = 'HED_DEK_QUALITY',
+  IMAGE_QUALITY = 'IMAGE_QUALITY',
+  NO_IMAGE = 'NO_IMAGE',
+  OFF_TOPIC = 'OFF_TOPIC',
+  ONE_SIDED = 'ONE_SIDED',
+  OTHER = 'OTHER',
+  PAYWALL = 'PAYWALL',
+  PUBLISHER_QUALITY = 'PUBLISHER_QUALITY',
+  SET_DIVERSITY = 'SET_DIVERSITY',
+}
+
 export type ApprovedItemRequiredInput = {
   prospectId?: string;
   title: string;
@@ -87,6 +102,11 @@ export type CreateSectionItemApiInput = {
   sectionExternalId: string;
   approvedItemExternalId: string;
   rank?: number;
+};
+
+export type RemoveSectionItemApiInput = {
+  externalId: string;
+  deactivateReasons: SectionItemRemovalReason[];
 };
 
 // maps to the CreateApprovedCorpusItemInput type in corpus API admin schema

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -102,6 +102,26 @@ enum RemovalReason {
 }
 
 """
+Reasons for removing SectionItems from ML Sections.
+
+This is used by ML downstream to improve their modeling.
+"""
+enum SectionItemRemovalReason {
+  ARTICLE_QUALITY
+  CONTROVERSIAL
+  DATED
+  HED_DEK_QUALITY
+  IMAGE_QUALITY
+  NO_IMAGE
+  OFF_TOPIC
+  ONE_SIDED
+  OTHER
+  PAYWALL
+  PUBLISHER_QUALITY
+  SET_DIVERSITY
+}
+
+"""
 Reasons for manually scheduling a corpus item.
 
 This is used by ML downstream to improve their modeling.
@@ -620,6 +640,20 @@ input CreateSectionItemInput {
   ML-generated SectionItems.
   """
   rank: Int
+}
+
+"""
+Input data for removing a SectionItem
+"""
+input RemoveSectionItemInput {
+  """
+  ID of the SectionItem. A string in UUID format.
+  """
+  externalId: ID!
+  """
+  Array of reasons for removing a SectionItem.
+  """
+  deactivateReasons: [SectionItemRemovalReason!]!
 }
 
 """
@@ -1277,7 +1311,7 @@ type Mutation {
   """
   Removes an active SectionItem from a Section.
   """
-  removeSectionItem(externalId: String!): SectionItem!
+  removeSectionItem(data: RemoveSectionItemInput!): SectionItem!
 
   """
   Disables or enables a Section. Can only be done from the admin tool.

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
@@ -59,12 +59,12 @@ export async function createSectionItem(
  */
 export async function removeSectionItem(
   parent,
-  args,
+  { data },
   context: IAdminContext,
 ): Promise<SectionItem> {
   // First check if the SectionItem exists & check if it is active
   const sectionItemToRemove =  await context.db.sectionItem.findUnique({
-    where: { externalId: args.externalId, active: true}
+    where: { externalId: data.externalId, active: true}
   });
 
   if(sectionItemToRemove) {
@@ -73,10 +73,10 @@ export async function removeSectionItem(
       throw new AuthenticationError(ACCESS_DENIED_ERROR);
     }
     
-    return await dbRemoveSectionItem(context.db, args.externalId);
+    return await dbRemoveSectionItem(context.db, {externalId: data.externalId, deactivateReasons: data.deactivateReasons});
   }
   // Check if SectionItem exists
   else {
-    throw new NotFoundError(`Cannot remove a section item: Section item with id "${args.externalId}" does not exist.`)
+    throw new NotFoundError(`Cannot remove a section item: Section item with id "${data.externalId}" does not exist.`)
   }
 }

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -120,8 +120,8 @@ export const CREATE_SECTION_ITEM = gql`
 `;
 
 export const REMOVE_SECTION_ITEM = gql`
-  mutation removeSectionItem($externalId: String!) {
-    removeSectionItem(externalId: $externalId) {
+  mutation removeSectionItem($data: RemoveSectionItemInput!) {
+    removeSectionItem(data: $data) {
       ...AdminSectionItemData
     }
   }

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
@@ -9,7 +9,7 @@ import {
 } from './SectionItem';
 import { createApprovedItemHelper } from '../../test/helpers';
 import { createSectionHelper } from '../../test/helpers';
-import { ActivitySource } from 'content-common';
+import { ActivitySource, SectionItemRemovalReason } from 'content-common';
 
 describe('SectionItem', () => {
   let db: PrismaClient;
@@ -48,7 +48,7 @@ describe('SectionItem', () => {
   });
 
   describe('removeSectionItem', () => {
-    it('should remove a SectionItem from a Section - mark it in-active & set deactivatedAt & deactivateSource', async () => {
+    it('should remove a SectionItem from a Section - mark it in-active, set deactivatedAt, deactivateSource & deactivateReasons', async () => {
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'Fake Item!',
       });
@@ -69,7 +69,12 @@ describe('SectionItem', () => {
         advanceTimers: false,
       });
 
-      const result = await removeSectionItem(db, sectionItem.externalId);
+      const input = {
+        externalId: sectionItem.externalId,
+        deactivateReasons: [SectionItemRemovalReason.DATED, SectionItemRemovalReason.CONTROVERSIAL]
+      };
+
+      const result = await removeSectionItem(db, input);
 
       // stop controlling `new Date()`
       jest.useRealTimers();
@@ -78,6 +83,7 @@ describe('SectionItem', () => {
       expect(result.active).toBeFalsy();
       expect(result.deactivateSource).toEqual(ActivitySource.MANUAL);
       expect(result.deactivatedAt).toEqual(newDateMock);
+      expect(result.deactivateReasons).toEqual(input.deactivateReasons);
     });
   });
 

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -2,7 +2,7 @@ import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 import { PrismaClient } from '.prisma/client';
 
-import { CreateSectionItemInput, SectionItem } from '../types';
+import { CreateSectionItemInput, RemoveSectionItemInput, SectionItem } from '../types';
 import { ActivitySource } from 'content-common';
 
 /**
@@ -56,27 +56,27 @@ export async function createSectionItem(
 }
 /**
  * This mutation removes a SectionItem from a Section.
- * The SectionItem is marked as in-active, `deactivatedBy` it set to MANUAL &
- * `deactivatedAt` Date is set.
+ * The SectionItem is marked as in-active, `deactivatedBy` it set to MANUAL,
+ * `deactivatedAt` Date is set & deactivateReasons is set.
  *
  * @param db
- * @param externalId
- * @param approvedItemId
+ * @param data
  */
 export async function removeSectionItem(
   db: PrismaClient,
-  externalId: string,
+  data: RemoveSectionItemInput,
 ): Promise<SectionItem> {
   // Construct the data to remove SectionItem
   const removeSectionItemData = {
     active: false,
+    deactivateReasons: data.deactivateReasons,
     deactivateSource: ActivitySource.MANUAL,
     deactivatedAt: new Date(),
   };
 
   return await db.sectionItem.update({
     where: {
-      externalId,
+      externalId: data.externalId,
       active: true,
     },
     data: removeSectionItemData,

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -12,6 +12,7 @@ import {
   ApprovedItemRequiredInput,
   CorpusItemSource,
   CorpusLanguage,
+  SectionItemRemovalReason,
 } from 'content-common';
 
 export type CreateApprovedItemInput = {
@@ -123,6 +124,11 @@ export type CreateSectionItemInput = {
   sectionId: number;
   approvedItemExternalId: string;
   rank?: number;
+};
+
+export type RemoveSectionItemInput = {
+  externalId: string;
+  deactivateReasons: SectionItemRemovalReason[];
 };
 
 export type DisableEnableSectionInput = {


### PR DESCRIPTION
## Goal

Updating `removeSectionItem` mutation to set & store new field `deactivateReasons`.

- Added new enum `SectionItemRemovalReason` enum in the graph, will be used in the admin tool
- Updated Graphql mutation `removeSectionItem` to take in `RemoveSectionItemInput`.
    - takes in `externalID` & array of `SectionItemRemovalReason` enum vals
- Updated resolver & db `removeSectionItem` to set & store `deactivateReasons`.
- Updated integration tests to check for the new `deactivateReasons`.

## Deployment steps

- [ ] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-500
