### PR TITLE
HNT-578: adding iab JSON on Section prisma

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20250428235231_add_iab_to_section/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20250428235231_add_iab_to_section/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Section` ADD COLUMN `iab` JSON NULL;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -109,6 +109,8 @@ model Section {
   externalId            String          @unique @default(uuid()) @db.VarChar(255)
   title                 String          @db.VarChar(255)
   scheduledSurfaceGuid  String          @db.VarChar(50)
+  // optional IAB info as as JSON blob: {taxonomy: 'IAB-3.0', categories: string[])
+  iab                   Json?
   // sort may only apply during initial experimentation with ML-generated Sections,
   // meaning this field may be dropped
   sort                  Int?


### PR DESCRIPTION
## Goal

Adding new optional field `iab` on `Section`. This will store the IAB taxonomy version & IAB category code(s) as a `json`:
```
{
  "taxonomy": "IAB-3.0",
  "categories": ["WQC6HR"]
}
```

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-578
