### PR TITLE
prospect source changes for pocket sunset

### DIFF
--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -139,15 +139,12 @@ export type CreateScheduledItemInput = {
 // these values will need to match those listed in the source of truth doc:
 // https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390642851/Pocket+Shared+Data#Prospect-Types
 export enum ProspectType {
-  COUNTS = 'COUNTS',
-  DISMISSED = 'DISMISSED',
   DOMAIN_ALLOWLIST = 'DOMAIN_ALLOWLIST',
   PUBLISHER_SUBMITTED = 'PUBLISHER_SUBMITTED',
   RECOMMENDED = 'RECOMMENDED',
   RSS_LOGISTIC = 'RSS_LOGISTIC',
   RSS_LOGISTIC_RECENT = 'RSS_LOGISTIC_RECENT',
   SLATE_SCHEDULER_V2 = 'SLATE_SCHEDULER_V2',
-  TIMESPENT = 'TIMESPENT',
   TITLE_URL_MODELED = 'TITLE_URL_MODELED',
   TOP_SAVED = 'TOP_SAVED',
   QA_ENTERTAINMENT = 'QA_ENTERTAINMENT',
@@ -264,12 +261,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_US',
     ianaTimezone: 'America/New_York',
     prospectTypes: [
-      ProspectType.COUNTS,
-      ProspectType.TIMESPENT,
-      ProspectType.TOP_SAVED,
       ProspectType.DOMAIN_ALLOWLIST,
-      ProspectType.DISMISSED,
-      ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.RSS_LOGISTIC_RECENT,
       ProspectType.SLATE_SCHEDULER_V2,
@@ -292,11 +284,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_DE_DE',
     ianaTimezone: 'Europe/Berlin',
     prospectTypes: [
-      ProspectType.COUNTS,
-      ProspectType.TIMESPENT,
       ProspectType.DOMAIN_ALLOWLIST,
-      ProspectType.DISMISSED,
-      ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.SLATE_SCHEDULER_V2,
       ProspectType.PUBLISHER_SUBMITTED,
@@ -310,10 +298,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_GB',
     ianaTimezone: 'Europe/London',
     prospectTypes: [
-      ProspectType.COUNTS,
-      ProspectType.TIMESPENT,
       ProspectType.RECOMMENDED,
-      ProspectType.DISMISSED,
       ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.PUBLISHER_SUBMITTED,
@@ -358,10 +343,7 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     guid: 'NEW_TAB_EN_INTL',
     ianaTimezone: 'Asia/Kolkata',
     prospectTypes: [
-      ProspectType.COUNTS,
-      ProspectType.TIMESPENT,
       ProspectType.RECOMMENDED,
-      ProspectType.DISMISSED,
       ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.PUBLISHER_SUBMITTED,

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -145,8 +145,6 @@ export enum ProspectType {
   RSS_LOGISTIC = 'RSS_LOGISTIC',
   RSS_LOGISTIC_RECENT = 'RSS_LOGISTIC_RECENT',
   SLATE_SCHEDULER_V2 = 'SLATE_SCHEDULER_V2',
-  TITLE_URL_MODELED = 'TITLE_URL_MODELED',
-  TOP_SAVED = 'TOP_SAVED',
   QA_ENTERTAINMENT = 'QA_ENTERTAINMENT',
   QA_SPORTS = 'QA_SPORTS',
   QA_MUSIC = 'QA_MUSIC',
@@ -299,7 +297,6 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     ianaTimezone: 'Europe/London',
     prospectTypes: [
       ProspectType.RECOMMENDED,
-      ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.PUBLISHER_SUBMITTED,
     ],
@@ -344,7 +341,6 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     ianaTimezone: 'Asia/Kolkata',
     prospectTypes: [
       ProspectType.RECOMMENDED,
-      ProspectType.TITLE_URL_MODELED,
       ProspectType.RSS_LOGISTIC,
       ProspectType.PUBLISHER_SUBMITTED,
     ],


### PR DESCRIPTION
## Goal

Various prospect sources are being decommissioned across multiple new tab scheduled surfaces as a result fo the pocket sunset and related snowflake sunset.

Changes are summarized in this [page](https://mozilla-hub.atlassian.net/wiki/x/JgHyW)

After this metaflow [PR](https://github.com/mozilla/content-ml-services/pull/549) is deployed, these changes should all take effect

Still need to update the pocket shared data [page](https://mozilla-hub.atlassian.net/wiki/x/o7xIFw)

## Implementation Decisions

- I did remove the `counts` `dismissed` and `timespent`  `top_saved` and `title_url_modeled` from ProspectType altogether.  happy to leave that in if that's preferred, but they should not be populated for any surface

## References

[confluence](https://mozilla-hub.atlassian.net/wiki/x/JgHyW)

