### PR TITLE
HNT-580: section-manager-lambda - handle IAB metadata

### DIFF
--- a/lambdas/section-manager-lambda/src/testHelpers.ts
+++ b/lambdas/section-manager-lambda/src/testHelpers.ts
@@ -2,6 +2,7 @@ import {
   CorpusItemSource,
   CorpusLanguage,
   CuratedStatus,
+  IABMetadata,
   ScheduledSurfacesEnum,
   Topics,
 } from 'content-common';
@@ -12,6 +13,11 @@ export const createSqsSectionWithSectionItems = (
   sqsSectionWithSectionItemsOverride: Partial<SqsSectionWithSectionItems> = {},
   candidateCount: number = 2,
 ): SqsSectionWithSectionItems => {
+  const iabMetadata: IABMetadata = {
+    taxonomy: "IAB-3.0",
+    categories: ["488"]
+  };
+
   const candidates: SqsSectionItem[] = [];
 
   for (let i = 0; i < candidateCount; i++) {
@@ -25,6 +31,7 @@ export const createSqsSectionWithSectionItems = (
     candidates,
     id: 'a4b5d99c-4c1b-4d35-bccf-6455c8df07b1',
     scheduled_surface_guid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
+    iab: iabMetadata,
     sort: 1,
     source: CorpusItemSource.ML,
     title: 'The Reindeer Section',

--- a/lambdas/section-manager-lambda/src/testHelpers.ts
+++ b/lambdas/section-manager-lambda/src/testHelpers.ts
@@ -14,8 +14,8 @@ export const createSqsSectionWithSectionItems = (
   candidateCount: number = 2,
 ): SqsSectionWithSectionItems => {
   const iabMetadata: IABMetadata = {
-    taxonomy: "IAB-3.0",
-    categories: ["488"]
+    taxonomy: 'IAB-3.0',
+    categories: ['488']
   };
 
   const candidates: SqsSectionItem[] = [];

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -2,6 +2,7 @@ import {
   CorpusItemSource,
   CorpusLanguage,
   CuratedStatus,
+  IABMetadata,
   ScheduledSurfacesEnum,
   Topics,
 } from 'content-common';
@@ -11,6 +12,7 @@ export interface SqsSectionWithSectionItems {
   candidates: SqsSectionItem[];
   id: string;
   scheduled_surface_guid: ScheduledSurfacesEnum;
+  iab?: IABMetadata;
   sort: number;
   source: CorpusItemSource.ML;
   title: string;
@@ -34,6 +36,7 @@ export type CreateOrUpdateSectionApiInput = {
   createSource: CorpusItemSource;
   externalId: string;
   scheduledSurfaceGuid: string;
+  iab?: IABMetadata;
   sort?: number;
   title: string;
 };

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   ScheduledSurfacesEnum,
   Topics,
   UrlMetadata,
+  IABMetadata,
 } from 'content-common';
 import {
   mapAuthorToApprovedItemAuthor,
@@ -73,11 +74,17 @@ describe('utils', () => {
 
   describe('mapSqsSectionDataToCreateOrUpdateSectionApiInput', () => {
     it('should map an SqsSectionWithSectionItems object to a CreateOrUpdateSectionApiInput object', () => {
+      const iabMetadata: IABMetadata = {
+        taxonomy: 'IAB-3.0',
+        categories: ['488']
+      };
+
       const sqsData: SqsSectionWithSectionItems = {
         active: true,
         candidates: [],
         id: 'test-id',
         scheduled_surface_guid: ScheduledSurfacesEnum.NEW_TAB_DE_DE,
+        iab: iabMetadata,
         sort: 42,
         source: CorpusItemSource.ML,
         title: 'test title',
@@ -92,6 +99,7 @@ describe('utils', () => {
       expect(apiInput.scheduledSurfaceGuid).toEqual(
         sqsData.scheduled_surface_guid,
       );
+      expect(apiInput.iab).toEqual(sqsData.iab);
       expect(apiInput.sort).toEqual(sqsData.sort);
       expect(apiInput.title).toEqual(sqsData.title);
     });

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -131,6 +131,7 @@ export const mapSqsSectionDataToCreateOrUpdateSectionApiInput = (
     createSource: sqsSectionData.source,
     externalId: sqsSectionData.id,
     scheduledSurfaceGuid: sqsSectionData.scheduled_surface_guid,
+    iab: sqsSectionData.iab,
     sort: sqsSectionData.sort,
     title: sqsSectionData.title,
   };

--- a/lambdas/section-manager-lambda/src/validators.spec.ts
+++ b/lambdas/section-manager-lambda/src/validators.spec.ts
@@ -92,6 +92,37 @@ describe('validation', function () {
           'Error on assert(): invalid type on $input.scheduled_surface_guid, expect to be ("NEW_TAB_DE_DE" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_ES_ES" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
         );
       });
+
+      it('should validate iab property', () => {
+        // iab is valid & should not throw error
+        expect(() => {
+          validateSqsData(sqsData);
+        }).not.toThrow();
+
+        // iab is optional and not present in payload, should not throw error
+        delete sqsData.iab;
+        expect(() => {
+          validateSqsData(sqsData);
+        }).not.toThrow();
+
+        // iab present & no taxonomy, should throw error
+        sqsData.iab = { invalid: 'iab-taxonomy', categories: ['ABC'] };
+
+        expect(() => {
+          validateSqsData(sqsData);
+        }).toThrow(
+          'Error on assert(): invalid type on $input.iab.taxonomy, expect to be string',
+        );
+
+        // iab present & no categories, should throw error
+        sqsData.iab = { taxonomy: 'IAB-3.0', invalid: ['category'] };
+
+        expect(() => {
+          validateSqsData(sqsData);
+        }).toThrow(
+          'Error on assert(): invalid type on $input.iab.categories, expect to be Array<string>',
+        );
+      });
     });
 
     describe('validate SectionItem data', () => {


### PR DESCRIPTION
## Goal

Section-Manager Lambda update: Adding an optional `iab` metadata to `SqsSectionWithSectionItems`.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-580