### PR TITLE
HNT-874: Add custom section metadata to Section prisma schema

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE `Section` ADD COLUMN `description` VARCHAR(255) NULL,
+    ADD COLUMN `endDate` DATE NULL,
+    ADD COLUMN `heroDescription` VARCHAR(255) NULL,
+    ADD COLUMN `heroTitle` VARCHAR(255) NULL,
+    ADD COLUMN `startDate` DATE NULL;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -108,6 +108,9 @@ model Section {
   // note - for ML-generated Sections, externalId will be set by ML
   externalId            String          @unique @default(uuid()) @db.VarChar(255)
   title                 String          @db.VarChar(255)
+  description           String?         @db.VarChar(255)
+  heroTitle             String?         @db.VarChar(255)
+  heroDescription       String?         @db.VarChar(255)
   scheduledSurfaceGuid  String          @db.VarChar(50)
   // optional IAB info as as JSON blob: {taxonomy: 'IAB-3.0', categories: string[])
   iab                   Json?
@@ -129,6 +132,8 @@ model Section {
   deactivatedAt         DateTime?
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
+  startDate             DateTime?       @db.Date
+  endDate               DateTime?       @db.Date
 
   // relations
   sectionItems          SectionItem[]


### PR DESCRIPTION
## Goal

Add custom section metadata to the `Section` prisma schema. All new metadata is optional.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-874
