### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # All Files/PRs
 
-* @MozillaSocial/content
+* @Pocket/content


### PR DESCRIPTION
## Goal
Change code owners from non-existing MozillaSocial/content to the [Pocket/content team](https://github.com/orgs/Pocket/teams/content).