### PR TITLE
Allow test-integrations to be required before merging

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,6 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,3 +40,11 @@ jobs:
       - name: Unit tests
         # Following uses a 2 concurrency because terraform modules seems to fail with an OOM error on CI if we do more.
         run: pnpm run test --concurrency=2
+
+  test-integrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy placeholder
+        run: |
+          echo "Ensuring 'test‑integrations' status check is always present"
+          echo "so branch protection rules can reliably require it."


### PR DESCRIPTION
## Goal
This PR introduces a no‑op `test-integrations` job to the Pull Request workflow. Its purpose is to ensure that a test‑integrations status check is always present on every PR, allowing branch protection rules to reliably require it without depending on path filters or other jobs. Without this no-op job, PRs that don't run any integration tests (such as documentation changes) would not be permitted to be merged in.

## References

[Slack thread](https://mozilla.slack.com/archives/C08JXUR7J5S/p1753905253611949?thread_ts=1753902935.518699&cid=C08JXUR7J5S)