### PR TITLE
Revert "HNT-874: Add custom section metadata to Section prisma schema"

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
@@ -1,6 +1,0 @@
--- AlterTable
-ALTER TABLE `Section` ADD COLUMN `description` VARCHAR(255) NULL,
-    ADD COLUMN `endDate` DATE NULL,
-    ADD COLUMN `heroDescription` VARCHAR(255) NULL,
-    ADD COLUMN `heroTitle` VARCHAR(255) NULL,
-    ADD COLUMN `startDate` DATE NULL;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -108,9 +108,6 @@ model Section {
   // note - for ML-generated Sections, externalId will be set by ML
   externalId            String          @unique @default(uuid()) @db.VarChar(255)
   title                 String          @db.VarChar(255)
-  description           String?         @db.VarChar(255)
-  heroTitle             String?         @db.VarChar(255)
-  heroDescription       String?         @db.VarChar(255)
   scheduledSurfaceGuid  String          @db.VarChar(50)
   // optional IAB info as as JSON blob: {taxonomy: 'IAB-3.0', categories: string[])
   iab                   Json?
@@ -132,8 +129,6 @@ model Section {
   deactivatedAt         DateTime?
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
-  startDate             DateTime?       @db.Date
-  endDate               DateTime?       @db.Date
 
   // relations
   sectionItems          SectionItem[]


### PR DESCRIPTION
## Goal
We want to undo the sections schema change and capitalization changes that were accidentally merged into main without review. The schema changes were accidentally re-introduced in 095f7707e8ced7419799ba46a10a983a00d5a837.

This PR reverts commit b6d34b1db7fb2492850d908af661a9a969eb524b.

I confirmed that this will get us back to a clean main state using git diff:
```
$ git diff 7faf25c1ec5c70febf61ba6cd6d6ce9bcb298d7b..095f7707e8ced7419799ba46a10a983a00d5a837
diff --git a/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql b/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
new file mode 100644
index 0000000..025e6ce
--- /dev/null
+++ b/servers/curated-corpus-api/prisma/migrations/20250729235557_add_custom_section_metadata_to_section/migration.sql
@@ -0,0 +1,6 @@
+-- AlterTable
+ALTER TABLE `Section` ADD COLUMN `description` VARCHAR(255) NULL,
+    ADD COLUMN `endDate` DATE NULL,
+    ADD COLUMN `heroDescription` VARCHAR(255) NULL,
+    ADD COLUMN `heroTitle` VARCHAR(255) NULL,
+    ADD COLUMN `startDate` DATE NULL;
diff --git a/servers/curated-corpus-api/prisma/schema.prisma b/servers/curated-corpus-api/prisma/schema.prisma
index 66ad213..243f965 100644
--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -108,6 +108,9 @@ model Section {
   // note - for ML-generated Sections, externalId will be set by ML
   externalId            String          @unique @default(uuid()) @db.VarChar(255)
   title                 String          @db.VarChar(255)
+  description           String?         @db.VarChar(255)
+  heroTitle             String?         @db.VarChar(255)
+  heroDescription       String?         @db.VarChar(255)
   scheduledSurfaceGuid  String          @db.VarChar(50)
   // optional IAB info as as JSON blob: {taxonomy: 'IAB-3.0', categories: string[])
   iab                   Json?
@@ -129,6 +132,8 @@ model Section {
   deactivatedAt         DateTime?
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
+  startDate             DateTime?       @db.Date
+  endDate               DateTime?       @db.Date
 
   // relations
   sectionItems          SectionItem[]
```