### PR TITLE
removing custom section metadata from Section prisma schema

### DIFF
--- a/servers/curated-corpus-api/prisma/migrations/20250730235022_remove_custom_section_metadata/migration.sql
+++ b/servers/curated-corpus-api/prisma/migrations/20250730235022_remove_custom_section_metadata/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `Section` table. All the data in the column will be lost.
+  - You are about to drop the column `endDate` on the `Section` table. All the data in the column will be lost.
+  - You are about to drop the column `heroDescription` on the `Section` table. All the data in the column will be lost.
+  - You are about to drop the column `heroTitle` on the `Section` table. All the data in the column will be lost.
+  - You are about to drop the column `startDate` on the `Section` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE `Section` DROP COLUMN `description`,
+    DROP COLUMN `endDate`,
+    DROP COLUMN `heroDescription`,
+    DROP COLUMN `heroTitle`,
+    DROP COLUMN `startDate`;

--- a/servers/curated-corpus-api/prisma/schema.prisma
+++ b/servers/curated-corpus-api/prisma/schema.prisma
@@ -108,9 +108,6 @@ model Section {
   // note - for ML-generated Sections, externalId will be set by ML
   externalId            String          @unique @default(uuid()) @db.VarChar(255)
   title                 String          @db.VarChar(255)
-  description           String?         @db.VarChar(255)
-  heroTitle             String?         @db.VarChar(255)
-  heroDescription       String?         @db.VarChar(255)
   scheduledSurfaceGuid  String          @db.VarChar(50)
   // optional IAB info as as JSON blob: {taxonomy: 'IAB-3.0', categories: string[])
   iab                   Json?
@@ -132,8 +129,6 @@ model Section {
   deactivatedAt         DateTime?
   createdAt             DateTime        @default(now())
   updatedAt             DateTime        @updatedAt
-  startDate             DateTime?       @db.Date
-  endDate               DateTime?       @db.Date
 
   // relations
   sectionItems          SectionItem[]


### PR DESCRIPTION
## Goal

This PR reverts commit b6d34b1db7fb2492850d908af661a9a969eb524b.

## I'd love feedback/perspectives on:

-

## Implementation Decisions

-

## Deployment steps

- [ ] Database migrations?
- [ ] Deployed to dev?
- [ ] Secrets?

## References

JIRA ticket:

- Link to JIRA ticket

Issue:

- Link to GitHub issue

Documentation:

- Project doc
