### PR TITLE
HNT-875-feat: add custom section metadata fields to GraphQL schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 dist
 logs
 cdktf.out
+dev.log
 
 # we only want pnpm-lock.yaml!
 package-lock.json

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -122,7 +122,7 @@ enum SectionItemRemovalReason {
 }
 
 """
-Status of a Section
+Represents the current Section status, computed dynamically.
 """
 enum SectionStatus {
   SCHEDULED
@@ -632,11 +632,11 @@ extend type Section {
   """
   status: SectionStatus
   """
-  The start date for when the Section should be active.
+  The start date for when the Section should be live.
   """
   startDate: Date
   """
-  The end date for when the Section should no longer be active.
+  The date when the Section is expired.
   """
   endDate: Date
 }

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -122,6 +122,16 @@ enum SectionItemRemovalReason {
 }
 
 """
+Status of a Section
+"""
+enum SectionStatus {
+  SCHEDULED
+  DISABLED
+  LIVE
+  EXPIRED
+}
+
+"""
 Reasons for manually scheduling a corpus item.
 
 This is used by ML downstream to improve their modeling.
@@ -617,6 +627,18 @@ extend type Section {
   A Unix timestamp of when the Section was last updated.
   """
   updatedAt: Int!
+  """
+  The status of the Section.
+  """
+  status: SectionStatus
+  """
+  The start date for when the Section should be active.
+  """
+  startDate: Date
+  """
+  The end date for when the Section should no longer be active.
+  """
+  endDate: Date
 }
 
 extend type SectionItem {

--- a/servers/curated-corpus-api/schema-shared.graphql
+++ b/servers/curated-corpus-api/schema-shared.graphql
@@ -101,6 +101,18 @@ type Section {
   This field returns an empty array when creating a new Section or updating a Section.
   """
   sectionItems: [SectionItem!]!
+  """
+  Optional description for the Section.
+  """
+  description: String
+  """
+  Optional hero title for the Section.
+  """
+  heroTitle: String
+  """
+  Optional hero description for the Section.
+  """
+  heroDescription: String
 }
 
 """


### PR DESCRIPTION
 What changed? What is the business/product goal?

  - Added custom metadata fields to GraphQL Section type to support editorial
  sections with enhanced content capabilities
  - Introduced section lifecycle management through status tracking and date-based
  scheduling to enable better control over section visibility and timing


  Implementation Decisions

  - Made all new fields optional to maintain backward compatibility with existing
  sections
  - Placed SectionStatus enum in admin schema only, as status management is an
  administrative function
  - Used Date scalar for date fields to align with existing date field patterns in
  the schema (e.g., scheduledDate)
  - Added editorial fields (description, heroTitle, heroDescription) to shared
  schema for client consumption

  Deployment steps

  - Database migrations? Yes - new columns needed for Section table
  - Deployed to dev? No
  - Secrets? No

  References

  JIRA ticket:

  - HNT-875


  Documentation:

  - ⚙️ Phase 3: Custom (Editorial) Sections - API Technical Specification (MVP) |
  :code: Corpus GraphQL API Updates

