### PR TITLE
Katerina/hnt 906

### DIFF
--- a/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
+++ b/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
@@ -85,6 +85,13 @@ export const createOrUpdateSection = async (
         mutation CreateOrUpdateSection($data: CreateOrUpdateSectionInput!) {
             createOrUpdateSection(data: $data) {
                 externalId
+                sectionItems {
+                  externalId
+                  approvedItem {
+                    externalId
+                    url
+                  }
+                }
             }
         }
     `;
@@ -107,8 +114,20 @@ export const createOrUpdateSection = async (
       `createOrUpdateSection mutation failed: ${result.errors[0].message}`,
     );
   }
+  const section = result.data.createOrUpdateSection;
 
-  return result.data.createOrUpdateSection;
+  const sectionItems = section.sectionItems || [];
+
+  return {
+    externalId: section.externalId,
+    sectionItems: sectionItems.map((item: any) => ({
+      externalId: item.externalId,
+      approvedItem: {
+        externalId: item.approvedItem.externalId,
+        url: item.approvedItem.url,
+      },
+    })),
+  };
 };
 
 /**
@@ -248,4 +267,3 @@ export async function removeSectionItem(
 
   return result.data.removeSectionItem.externalId;
 }
-

--- a/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
+++ b/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
@@ -10,6 +10,7 @@ import {
 
 import config from './config';
 import {
+  ActiveSectionItem,
   CreateSectionItemApiInput,
   CreateOrUpdateSectionApiInput,
   RemoveSectionItemApiInput,
@@ -68,13 +69,7 @@ export const createOrUpdateSection = async (
   data: CreateOrUpdateSectionApiInput,
 ): Promise<{
   externalId: string;
-  sectionItems: {
-    externalId: string;
-    approvedItem: {
-      externalId: string;
-      url: string;
-    };
-  }[];
+  sectionItems: ActiveSectionItem[];
 }> => {
   // throttle calls to the admin graph
   await sleep(2000);

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -30,7 +30,15 @@ export interface SqsSectionItem {
   title: string | null;
   topic: Topics;
   url: string;
-}
+};
+
+export interface ActiveSectionItem {
+  externalId: string;
+  approvedItem: {
+    externalId: string;
+    url: string;
+  };
+};
 
 export type CreateOrUpdateSectionApiInput = {
   active: boolean;

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -4,6 +4,7 @@ import {
   CuratedStatus,
   IABMetadata,
   ScheduledSurfacesEnum,
+  SectionItemRemovalReason,
   Topics,
 } from 'content-common';
 
@@ -49,5 +50,6 @@ export type CreateSectionItemApiInput = {
 
 export type RemoveSectionItemApiInput = {
   externalId: string;
+  deactivateReasons: SectionItemRemovalReason[];
   deactivateSource: CorpusItemSource;
 };

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -46,3 +46,8 @@ export type CreateSectionItemApiInput = {
   sectionExternalId: string;
   rank?: number;
 };
+
+export type RemoveSectionItemApiInput = {
+  externalId: string;
+  deactivateSource: CorpusItemSource;
+};

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -331,6 +331,11 @@ describe('utils', () => {
       {},
       sectionItemCount,
     );
+    // ensure each candidate URL is unique to test de-dupe logic
+    sqsSectionData.candidates = sqsSectionData.candidates.map((candidate, i) => ({
+      ...candidate,
+      url: `https://example-${i}.com`,
+    }));
     const jwtBearerToken = 'testJwtBearerToken';
 
     // mock all the functions orchestrated by processSqsSectionData.
@@ -366,7 +371,7 @@ describe('utils', () => {
 
       mockCreateOrUpdateSection = jest
         .spyOn(GraphQlApiCalls, 'createOrUpdateSection')
-        .mockResolvedValue('sectionExternalId1');
+        .mockResolvedValue({externalId: 'sectionExternalId1', sectionItems: []});
 
       mockGetUrlMetadata = jest
         .spyOn(GraphQlApiCalls, 'getUrlMetadata')
@@ -385,6 +390,39 @@ describe('utils', () => {
         .mockResolvedValue('sectionItemExternalId1');
     });
 
+    it('returns sectionItems from createOrUpdateSection when updating section', async () => {
+      const mockSectionItems = [
+        {
+          externalId: 'sectionItemExternalId1',
+          approvedItem: {
+            externalId: 'approvedItemExternalId1',
+            url: 'https://example-one.com',
+          },
+        },
+        {
+          externalId: 'sectionItemExternalId2',
+          approvedItem: {
+            externalId: 'approvedItemExternalId2',
+            url: 'https://example-two.com',
+          },
+        },
+      ];
+
+      mockCreateOrUpdateSection.mockResolvedValue({
+        externalId: 'sectionExternalId1',
+        sectionItems: mockSectionItems,
+      });
+
+      await Utils.processSqsSectionData(sqsSectionData, jwtBearerToken);
+
+      expect(mockCreateOrUpdateSection).toHaveBeenCalledTimes(1);
+      const sectionResponse = await mockCreateOrUpdateSection.mock.results[0].value;
+
+      expect(sectionResponse.externalId).toEqual('sectionExternalId1')
+      // check sectionItems are returned in response
+      expect(sectionResponse.sectionItems).toEqual(mockSectionItems);
+    });
+
     it('calls the expected functions if the section items already exist in the corpus', async () => {
       // make sure all the section items "exist" in the corpus
       const mockGetApprovedCorpusItemByUrl = jest
@@ -393,6 +431,7 @@ describe('utils', () => {
           externalId: 'approvedItemExternalId1',
           url: 'test.com',
         });
+
 
       await Utils.processSqsSectionData(sqsSectionData, jwtBearerToken);
 
@@ -420,8 +459,11 @@ describe('utils', () => {
       // Check that all 3 candidates processed, 0 failures
       expect(sentryStub).toHaveBeenCalledTimes(0);
       expect(mockConsoleError).toHaveBeenCalledTimes(0);
-      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2);
       expect(mockConsoleLog.mock.calls[0][0]).toContain(
+        `No SectionItems to remove for Section sectionExternalId1`,
+      );
+      expect(mockConsoleLog.mock.calls[1][0]).toContain(
         'processSqsSectionData result: 3 succeeded, 0 failed',
       );
     });
@@ -459,8 +501,11 @@ describe('utils', () => {
       // Check that all 3 candidates processed, 0 failures
       expect(sentryStub).toHaveBeenCalledTimes(0);
       expect(mockConsoleError).toHaveBeenCalledTimes(0);
-      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2);
       expect(mockConsoleLog.mock.calls[0][0]).toContain(
+        `No SectionItems to remove for Section sectionExternalId1`,
+      );
+      expect(mockConsoleLog.mock.calls[1][0]).toContain(
         'processSqsSectionData result: 3 succeeded, 0 failed',
       );
     });
@@ -506,9 +551,76 @@ describe('utils', () => {
       );
 
       // Check that 2 candidates were processed & 1 failed
-      expect(mockConsoleLog).toHaveBeenCalledTimes(1);
+      expect(mockConsoleLog).toHaveBeenCalledTimes(2);
       expect(mockConsoleLog.mock.calls[0][0]).toContain(
+        `No SectionItems to remove for Section sectionExternalId1`,
+      );
+      expect(mockConsoleLog.mock.calls[1][0]).toContain(
         'processSqsSectionData result: 2 succeeded, 1 failed',
+      );
+    });
+
+    it('calls the expected functions when creating ML SectionItems first, ignoring dupes, then removing old SectionItems, with deactivateSource=ML', async () => {
+      const url1 = 'https://example-one.com';
+      const url2 = 'https://example-two.com';
+      const url3 = 'https://example-three.com';
+
+      // Existing Section (to update) already has SectionItems with URLS 1 & 2
+      mockCreateOrUpdateSection.mockResolvedValue({
+        externalId: 'sectionExternalId1',
+        sectionItems: [
+          {
+            externalId: 'sectionItem1',
+            approvedItem: { externalId: 'approvedItem1', url: url1 },
+          },
+          {
+            externalId: 'sectionItem2',
+            approvedItem: { externalId: 'approvedItem2', url: url2 },
+          },
+        ],
+      });
+
+      // ML sends SectionItem payload with URL2 (already active) + URL3 (new)
+      const sqs = createSqsSectionWithSectionItems({}, 0);
+      sqs.candidates = [
+        { url: url2, rank: 1 } as any,
+        { url: url3, rank: 2 } as any,
+      ];
+
+      // Mock ApprovedItem lookup
+      jest.spyOn(GraphQlApiCalls, 'getApprovedCorpusItemByUrl')
+        .mockImplementation(async (_endpoint, _headers, url) => {
+          if (url === url2) return { externalId: 'approvedItem2', url: url2 };
+          if (url === url3) return { externalId: 'approvedItem3', url: url3 };
+          return null;
+        });
+
+      const mockRemoveSectionItem = jest
+        .spyOn(GraphQlApiCalls, 'removeSectionItem')
+        .mockResolvedValue('sectionItem1');
+
+      await Utils.processSqsSectionData(sqs, jwtBearerToken);
+
+      // Only create SectionItem with URL3 (SectionItem with URL2 is already active (dupe))
+      expect(mockCreateSectionItem).toHaveBeenCalledTimes(1);
+      expect(mockCreateSectionItem).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          approvedItemExternalId: 'approvedItem3',
+          rank: 2,
+        }),
+      );
+
+      // Only remove SectionItem with URL1
+      expect(mockRemoveSectionItem).toHaveBeenCalledTimes(1);
+      expect(mockRemoveSectionItem).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        expect.objectContaining({
+          externalId: 'sectionItem1',
+          deactivateSource: 'ML',
+        }),
       );
     });
   });

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -69,13 +69,16 @@ export const processSqsSectionData = async (
   const sectionExternalId =  sectionResult.externalId;
   const activeSectionItems = sectionResult.sectionItems || [];
 
+  console.log('activeSectionItems: ', activeSectionItems)
+
   // keep track of how many candidates succeeded, how many failed
   let successfulCandidates = 0;
   let failedCandidates = 0;
 
   // Get the currently active SectionItems URLs & SectionItems to remove
   const { activeSectionItemsUrlsSet, sectionItemsToRemove } = computeSectionItemsDiff(sqsSectionData, activeSectionItems);
-
+  console.log('activeSectionItemsUrlsSet: ', activeSectionItemsUrlsSet)
+  console.log('sectionItemsToRemove: ', sectionItemsToRemove)
   // for each SectionItem, see if the URL already exists in the corpus
   for (let i = 0; i < sqsSectionData.candidates.length; i++) {
     // convenience!
@@ -84,6 +87,7 @@ export const processSqsSectionData = async (
       let approvedItemExternalId: string;
       // avoid creating SectionItem duplicates if the URL already exists
       if (activeSectionItemsUrlsSet.has(sqsSectionItem.url)) {
+        console.log('duplicate!: ', sqsSectionItem.url)
         continue;
       }
       // see if the Corpus has an ApprovedItem matching the SectionItem's URL

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -10,6 +10,7 @@ import {
   formatQuotesDashesDE,
   UrlMetadata,
   CorpusItemSource,
+  SectionItemRemovalReason,
 } from 'content-common';
 import {
   generateGraphQlApiHeaders,
@@ -155,6 +156,7 @@ export const processSqsSectionData = async (
       try {
         await removeSectionItem(config.adminApiEndpoint, graphHeaders, {
           externalId: item.externalId,
+          deactivateReasons: [SectionItemRemovalReason.OTHER],
           deactivateSource: CorpusItemSource.ML,
         });
       } catch (e) {

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -69,16 +69,13 @@ export const processSqsSectionData = async (
   const sectionExternalId =  sectionResult.externalId;
   const activeSectionItems = sectionResult.sectionItems || [];
 
-  console.log('activeSectionItems: ', activeSectionItems)
-
   // keep track of how many candidates succeeded, how many failed
   let successfulCandidates = 0;
   let failedCandidates = 0;
 
   // Get the currently active SectionItems URLs & SectionItems to remove
   const { activeSectionItemsUrlsSet, sectionItemsToRemove } = computeSectionItemsDiff(sqsSectionData, activeSectionItems);
-  console.log('activeSectionItemsUrlsSet: ', activeSectionItemsUrlsSet)
-  console.log('sectionItemsToRemove: ', sectionItemsToRemove)
+
   // for each SectionItem, see if the URL already exists in the corpus
   for (let i = 0; i < sqsSectionData.candidates.length; i++) {
     // convenience!
@@ -87,7 +84,6 @@ export const processSqsSectionData = async (
       let approvedItemExternalId: string;
       // avoid creating SectionItem duplicates if the URL already exists
       if (activeSectionItemsUrlsSet.has(sqsSectionItem.url)) {
-        console.log('duplicate!: ', sqsSectionItem.url)
         continue;
       }
       // see if the Corpus has an ApprovedItem matching the SectionItem's URL

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -113,6 +113,7 @@ export type CreateSectionItemApiInput = {
 export type RemoveSectionItemApiInput = {
   externalId: string;
   deactivateReasons: SectionItemRemovalReason[];
+  deactivateSource?: ActivitySource;
 };
 
 // maps to the CreateApprovedCorpusItemInput type in corpus API admin schema

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -688,6 +688,11 @@ input RemoveSectionItemInput {
   Array of reasons for removing a SectionItem.
   """
   deactivateReasons: [SectionItemRemovalReason!]!
+  """
+  Indicates which source deactivated the SectionItem.
+  Optional; MANUAL if omitted
+  """
+  deactivateSource: ActivitySource
 }
 
 """

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
@@ -73,7 +73,7 @@ export async function removeSectionItem(
       throw new AuthenticationError(ACCESS_DENIED_ERROR);
     }
     
-    return await dbRemoveSectionItem(context.db, {externalId: data.externalId, deactivateReasons: data.deactivateReasons});
+    return await dbRemoveSectionItem(context.db, {externalId: data.externalId, deactivateReasons: data.deactivateReasons, deactivateSource: data.deactivateSource});
   }
   // Check if SectionItem exists
   else {

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -70,7 +70,7 @@ export async function removeSectionItem(
   const removeSectionItemData = {
     active: false,
     deactivateReasons: data.deactivateReasons,
-    deactivateSource: ActivitySource.MANUAL,
+    deactivateSource: data.deactivateSource ?? ActivitySource.MANUAL,
     deactivatedAt: new Date(),
   };
 

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -131,6 +131,7 @@ export type CreateSectionItemInput = {
 export type RemoveSectionItemInput = {
   externalId: string;
   deactivateReasons: SectionItemRemovalReason[];
+  deactivateSource?: ActivitySource;
 };
 
 export type DisableEnableSectionInput = {


### PR DESCRIPTION
## Goal

Currently, section items become unavailable during the time the section is updated. For some sections this is about half a minute every 10 minutes. 

- Update `createOrUpdateSection` mutation to no longer deactivate "old" `SectionItems` when updating an existing Section.
- Instead, `section-manager-lambda` creates new `SectionItems` from the ML payload
    - add de-duplicate logic -- if existing approved corpus item is sent in the payload, skip creation
    - Return active `SectionItems` for a `Section` when updating an existing `Section`. This is used to compute the diff betwene the API response & ML payload when comparing `SectionItems`.
- After creating new `SectionItems`, call `removeSectionItem` mutation to remove existing "old" `SectionItems` from the `Section` that were not present in the ML payload
    - Update `removeSectionItem` mutation to optionally accept `deactivateSource`. If not present, default to `MANUAL`
- Update tests

## Deployment steps

- [x] Deployed to dev
    - https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FSectionManagerLambda-Dev-SQS-Function/log-events/2025$252F08$252F13$252F$255B60$255D70608940c1334c48958dfab64846173f
    - https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252FSectionManagerLambda-Dev-SQS-Function/log-events/2025$252F08$252F13$252F$255B60$255D0ef153d1898e4ccfa830b34dbc55f4c4

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-906