### PR TITLE
HNT-add-updateCustomSection-mutation

### DIFF
--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -104,6 +104,24 @@ export type DisableEnableSectionApiInput = {
   disabled: boolean;
 };
 
+export type UpdateCustomSectionApiInput = {
+  externalId: string;           // identifier for the Section being updated
+  title?: string;
+  description?: string;
+  heroTitle?: string;
+  heroDescription?: string;
+  startDate?: string;           // YYYY-MM-DD
+  endDate?: string;             // YYYY-MM-DD
+  scheduledSurfaceGuid?: string;
+  iab?: IABMetadata;
+  sort?: number | null;         // allow null to clear
+  // createSource is intentionally NOT updatable for custom sections,
+  // but if present, enforce MANUAL (see resolver).
+  createSource?: ActivitySource;
+  active?: boolean;
+  disabled?: boolean;           // still admin-only; keep behavior consistent with disableEnableSection
+};
+
 export type CreateSectionItemApiInput = {
   sectionExternalId: string;
   approvedItemExternalId: string;

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -1222,6 +1222,71 @@ type Mutation {
   Disables or enables a Section. Can only be done from the admin tool.
   """
   disableEnableSection(data: DisableEnableSectionInput!): Section!
+
+  """
+  Updates an existing Custom (Editorial) Section. Admin-only.
+  The target Section is identified by its externalId.
+  Only provided fields will be updated.
+  """
+  updateCustomSection(data: UpdateCustomSectionInput!): Section!
+}
+
+"""
+Input data for updating a Custom (Editorial) Section.
+"""
+input UpdateCustomSectionInput {
+  """
+  The title of the custom section displayed to the users.
+  """
+  title: String!
+  """
+  The description of the custom section displayed to the users.
+  """
+  description: String!
+  """
+  An optional title used in hero modules.
+  """
+  heroTitle: String
+  """
+  An optional description or supporting text for use in hero modules.
+  """
+  heroDescription: String
+  """
+  The date of when the Section should go "live" for display on NewTab.
+  Current & future dates allowed.
+  Format: YYYY-MM-DD.
+  """
+  startDate: Date!
+  """
+  An optional date of when the Section should stop being displayed.
+  Format: YYYY-MM-DD.
+  """
+  endDate: Date
+  """
+  The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'.
+  """
+  scheduledSurfaceGuid: ID!
+  """
+  Optional IAB metadata input
+  """
+  iab: IABMetadataInput
+  """
+  The source which created the Section.
+  """
+  createSource: ActivitySource!
+  """
+  Controls the display order of Sections.
+  """
+  sort: Int
+  """
+  Indicates whether or not a Section is available for display.
+  """
+  active: Boolean!
+  """
+  Indicates whether or not a Section is fully disabled from display on NewTab. Can only  be controlled
+  in the admin tool.
+  """
+  disabled: Boolean!
 }
 
 """

--- a/servers/curated-corpus-api/src/admin/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/index.ts
@@ -29,7 +29,7 @@ import {
 import { getOpenGraphFields } from './queries/OpenGraphFields';
 import { hasTrustedDomain } from './queries/ApprovedItem/hasTrustedDomain';
 import { getSectionsWithSectionItems } from './queries/Section';
-import { createOrUpdateSection, disableEnableSection } from './mutations/Section';
+import { createOrUpdateSection, disableEnableSection, updateCustomSection } from './mutations/Section';
 import { createSectionItem, removeSectionItem } from './mutations/SectionItem';
 
 export const resolvers = {
@@ -117,6 +117,7 @@ export const resolvers = {
     uploadApprovedCorpusItemImage: uploadApprovedItemImage,
     createScheduleReview: createScheduleReview,
     createOrUpdateSection: createOrUpdateSection,
+    updateCustomSection: updateCustomSection,
     createSectionItem: createSectionItem,
     removeSectionItem: removeSectionItem,
     disableEnableSection: disableEnableSection,

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/updateCustomSection.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/updateCustomSection.integration.ts
@@ -1,0 +1,134 @@
+import { print } from 'graphql';
+import request from 'supertest';
+
+import { ApolloServer } from '@apollo/server';
+import { PrismaClient } from '.prisma/client';
+
+import {
+  ActivitySource,
+  ScheduledSurfacesEnum,
+} from 'content-common';
+
+import { client } from '../../../../database/client';
+
+import {
+  clearDb,
+  createSectionHelper,
+} from '../../../../test/helpers';
+
+import { UPDATE_CUSTOM_SECTION } from '../sample-mutations.gql';
+import { startServer } from '../../../../express';
+import { IAdminContext } from '../../../context';
+
+describe('mutations: Section (updateCustomSection)', () => {
+  let app: any;
+  let adminServer: ApolloServer<IAdminContext>;
+  let prisma: PrismaClient;
+
+  const SURFACE = ScheduledSurfacesEnum.SANDBOX;
+  const SECTION_EXTERNAL_ID = 'SECTION-CUSTOM-1';
+  const SECTION_EXTERNAL_ID_2 = 'SECTION-CUSTOM-2'; // present but not used for slug anymore
+
+  beforeAll(async () => {
+    prisma = client(); // factory → call it
+    await clearDb(prisma);
+
+    // boot the app the same way as sibling tests
+    const started = await startServer(0);
+    app = started.app;
+    adminServer = started.adminServer;
+
+    // seed baseline sections using the helper (no slug/sort here)
+    await createSectionHelper(prisma, {
+      externalId: SECTION_EXTERNAL_ID,
+      title: 'Original Title',
+      scheduledSurfaceGuid: SURFACE,
+      iab: null,
+      createSource: ActivitySource.ML,
+      active: true,
+      disabled: false,
+    });
+
+    await createSectionHelper(prisma, {
+      externalId: SECTION_EXTERNAL_ID_2,
+      title: 'Other Section',
+      scheduledSurfaceGuid: SURFACE,
+      iab: null,
+      createSource: ActivitySource.ML,
+      active: true,
+      disabled: false,
+    });
+  });
+
+  afterAll(async () => {
+    await adminServer?.stop();
+    await prisma?.$disconnect();
+  });
+
+  it('updates a custom section (happy path)', async () => {
+    const variables = {
+      data: {
+        externalId: SECTION_EXTERNAL_ID,
+        title: 'Editors’ Picks',
+        dek: 'Fresh reads, hand-picked',
+        description: 'A rotating set of editorial selections',
+        imageUrl: 'https://cdn.example/picks.jpg',
+        isPublished: true,
+        // If your DB layer maps sortOrder -> sort, this will still be persisted
+        sortOrder: 42,
+      },
+    };
+
+    const res = await request(app)
+      .post('/admin')
+      .send({
+        query: print(UPDATE_CUSTOM_SECTION),
+        variables,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.errors).toBeUndefined();
+
+    const section = res.body.data?.updateCustomSection;
+    expect(section).toBeTruthy();
+    expect(section.externalId).toEqual(SECTION_EXTERNAL_ID);
+    expect(section.title).toEqual('Editors’ Picks');
+    expect(section.dek).toEqual('Fresh reads, hand-picked');
+    expect(section.description).toEqual('A rotating set of editorial selections');
+    expect(section.imageUrl).toEqual('https://cdn.example/picks.jpg');
+    expect(section.isPublished).toBe(true);
+
+    // sectionItems is included by your DB mutation include; may be empty and that's OK
+    expect(Array.isArray(section.sectionItems)).toBe(true);
+  });
+
+  it('returns NotFoundError when section does not exist', async () => {
+    const res = await request(app)
+      .post('/admin')
+      .send({
+        query: print(UPDATE_CUSTOM_SECTION),
+        variables: {
+          data: { externalId: 'DOES-NOT-EXIST', title: 'Nope' },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+    const [err] = res.body.errors;
+    expect(err.message).toMatch(/does not exist/i);
+  });
+
+  it('returns BAD_USER_INPUT when no updatable fields provided', async () => {
+    const res = await request(app)
+      .post('/admin')
+      .send({
+        query: print(UPDATE_CUSTOM_SECTION),
+        variables: { data: { externalId: SECTION_EXTERNAL_ID } },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+    const [err] = res.body.errors;
+    expect(err.message).toMatch(/No updatable fields provided/i);
+  });
+});

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -30,6 +30,16 @@ export const UPDATE_APPROVED_ITEM = gql`
   ${AdminCuratedItemData}
 `;
 
+export const UPDATE_CUSTOM_SECTION = gql`
+    mutation updateCustomSection($data: UpdateCustomSectionInput!) {
+        updateCustomSection(data: $data) {
+            ...AdminSectionData
+        }
+    }
+    ${AdminSectionData}
+`;
+
+
 export const REJECT_APPROVED_ITEM = gql`
   mutation rejectApprovedItem($data: RejectApprovedCorpusItemInput!) {
     rejectApprovedCorpusItem(data: $data) {

--- a/servers/curated-corpus-api/src/database/mutations/index.ts
+++ b/servers/curated-corpus-api/src/database/mutations/index.ts
@@ -11,4 +11,5 @@ export {
 } from './ScheduledItem';
 export { createScheduleReview } from './ScheduleReview';
 export { createSection, disableEnableSection, updateSection } from './Section';
+export { updateCustomSection } from './Section';
 export { createSectionItem, removeSectionItem } from './SectionItem';

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -128,6 +128,22 @@ export type CreateSectionItemInput = {
   rank?: number;
 };
 
+export type UpdateCustomSectionInput = {
+  externalId: string;
+  title?: string;
+  description?: string;
+  heroTitle?: string;
+  heroDescription?: string;
+  startDate?: string;      // YYYY-MM-DD
+  endDate?: string;        // YYYY-MM-DD
+  scheduledSurfaceGuid?: string;
+  iab?: IABMetadata;
+  sort?: number | null;
+  active?: boolean;
+  disabled?: boolean;
+  createSource?: ActivitySource; // will be ignored/validated in resolver
+};
+
 export type RemoveSectionItemInput = {
   externalId: string;
   deactivateReasons: SectionItemRemovalReason[];


### PR DESCRIPTION
### **Goal**

**What changed? What is the business/product goal?**

Add GraphQL schema + resolver + DB mutation for updateCustomSection.

Ensure parity with createCustomSection (IAB validation, surface permissions, etc.).

Allow curators/admins to update only the fields provided.

### **I'd love feedback/perspectives on:**

Should createSource be included in UpdateCustomSectionInput at all, or should we enforce immutability by leaving it out of the schema?

Do we want disabled updates to flow only through disableEnableSection mutation, or allow it here too for convenience?

Return shape: should updateCustomSection return sectionItems (with approvedItem) like createCustomSection does, or keep it leaner?
