### PR TITLE
HNT-968-HNT-969: section manager lambda passes section description to corpus-api

### DIFF
--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -17,6 +17,7 @@ export interface SqsSectionWithSectionItems {
   sort: number;
   source: CorpusItemSource.ML;
   title: string;
+  description?: string;
 }
 
 export interface SqsSectionItem {
@@ -48,6 +49,7 @@ export type CreateOrUpdateSectionApiInput = {
   iab?: IABMetadata;
   sort?: number;
   title: string;
+  description?: string;
 };
 
 export type CreateSectionItemApiInput = {

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -89,6 +89,7 @@ describe('utils', () => {
         sort: 42,
         source: CorpusItemSource.ML,
         title: 'test title',
+        description: 'test description'
       };
 
       const apiInput =
@@ -103,6 +104,7 @@ describe('utils', () => {
       expect(apiInput.iab).toEqual(sqsData.iab);
       expect(apiInput.sort).toEqual(sqsData.sort);
       expect(apiInput.title).toEqual(sqsData.title);
+      expect(apiInput.description).toEqual(sqsData.description);
     });
   });
 

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -208,6 +208,7 @@ export const mapSqsSectionDataToCreateOrUpdateSectionApiInput = (
     iab: sqsSectionData.iab,
     sort: sqsSectionData.sort,
     title: sqsSectionData.title,
+    description: sqsSectionData.description,
   };
 };
 

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -93,6 +93,7 @@ export type ApprovedItemRequiredInput = {
 export type CreateOrUpdateSectionApiInput = {
   externalId: string;
   title: string;
+  description?: string;
   scheduledSurfaceGuid: string;
   iab?: IABMetadata;
   sort?: number;

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -578,6 +578,10 @@ input CreateOrUpdateSectionInput {
   """
   title: String!
   """
+  The optional description of the Section displayed to the users.
+  """
+  description: String
+  """
   The GUID of the Scheduled Surface. Example: 'NEW_TAB_EN_US'.
   """
   scheduledSurfaceGuid: ID!

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/createOrUpdateSection.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/Section/createOrUpdateSection.integration.ts
@@ -84,6 +84,7 @@ describe('mutations: Section (createOrUpdateSection)', () => {
     input = {
       externalId: '123-abc',
       title: 'Fake Section Title',
+      description: 'Fake description',
       scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
       iab: iabMetadata,
       sort: 1,
@@ -108,6 +109,9 @@ describe('mutations: Section (createOrUpdateSection)', () => {
     );
     expect(result.body.data?.createOrUpdateSection.title).toEqual(
       'Fake Section Title',
+    );
+    expect(result.body.data?.createOrUpdateSection.description).toEqual(
+      'Fake description',
     );
     expect(
       result.body.data?.createOrUpdateSection.scheduledSurfaceGuid,
@@ -165,6 +169,7 @@ describe('mutations: Section (createOrUpdateSection)', () => {
     input = {
       externalId: 'bcg-456',
       title: 'Updating Fake Section Title',
+      description: 'Updating fake description',
       scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
       iab: iabMetadata,
       createSource: ActivitySource.ML,
@@ -195,6 +200,9 @@ describe('mutations: Section (createOrUpdateSection)', () => {
     );
     expect(result.body.data?.createOrUpdateSection.title).toEqual(
       'Updating Fake Section Title',
+    );
+    expect(result.body.data?.createOrUpdateSection.description).toEqual(
+      'Updating fake description',
     );
     expect(
       result.body.data?.createOrUpdateSection.scheduledSurfaceGuid,

--- a/servers/curated-corpus-api/src/database/mutations/Section.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/Section.integration.ts
@@ -46,6 +46,7 @@ describe('Section', () => {
       const input = {
         externalId: 'njh-789',
         title: 'Fake Section Title',
+        description: 'Fake section description',
         scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
         iab: iabMetadata,
         createSource: ActivitySource.MANUAL,
@@ -68,6 +69,7 @@ describe('Section', () => {
       const section = await createSectionHelper(db, {
         externalId: 'oiueh-123',
         title: 'New Title',
+        description: 'Fake description'
       });
 
       const sectionItem = await createSectionItemHelper(db, {
@@ -101,6 +103,7 @@ describe('Section', () => {
       const input = {
         externalId: 'oiueh-123',
         title: 'Updating new title',
+        description: 'Updating new description',
         scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
         createSource: ActivitySource.MANUAL,
         sort: 3,
@@ -111,6 +114,7 @@ describe('Section', () => {
 
       expect(result.externalId).toEqual('oiueh-123');
       expect(result.title).toEqual('Updating new title');
+      expect(result.description).toEqual('Updating new description');
       // exepct deactivateSource to be null
       expect(result.deactivateSource).toBeNull();
       expect(result.sort).toEqual(3);

--- a/servers/curated-corpus-api/src/database/mutations/Section.ts
+++ b/servers/curated-corpus-api/src/database/mutations/Section.ts
@@ -17,6 +17,7 @@ export async function createSection(
   const {
     externalId,
     title,
+    description,
     scheduledSurfaceGuid,
     iab,
     sort,
@@ -27,6 +28,7 @@ export async function createSection(
   const createData = {
     externalId,
     title,
+    description,
     scheduledSurfaceGuid,
     iab,
     sort,
@@ -57,10 +59,11 @@ export async function updateSection(
   data: CreateSectionInput,
   sectionId: number,
 ): Promise<Section> {
-  const { externalId, title, scheduledSurfaceGuid, iab, sort, active } = data;
+  const { externalId, title, description, scheduledSurfaceGuid, iab, sort, active } = data;
 
   const sectionUpdateData: Prisma.SectionUpdateInput = {
     title,
+    description,
     scheduledSurfaceGuid,
     iab,
     sort,

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -115,6 +115,7 @@ export type CreateScheduleReviewInput = {
 export type CreateSectionInput = {
   externalId: string;
   title: string;
+  description?: string;
   scheduledSurfaceGuid: string;
   iab?: IABMetadata,
   sort?: number;

--- a/servers/curated-corpus-api/src/test/helpers/createSectionHelper.integration.ts
+++ b/servers/curated-corpus-api/src/test/helpers/createSectionHelper.integration.ts
@@ -34,6 +34,7 @@ describe('createSectionHelper', () => {
       externalId: 'AnExternalIdFromML',
       scheduledSurfaceGuid: ScheduledSurfacesEnum.NEW_TAB_EN_US,
       title: 'How to Build Community',
+      description: 'a small description here'
     };
 
     const section: Section = await createSectionHelper(db, data);
@@ -43,5 +44,6 @@ describe('createSectionHelper', () => {
     expect(section.externalId).toEqual(data.externalId);
     expect(section.scheduledSurfaceGuid).toEqual(data.scheduledSurfaceGuid);
     expect(section.title).toEqual(data.title);
+    expect(section.description).toEqual(data.description);
   });
 });

--- a/servers/curated-corpus-api/src/test/helpers/createSectionHelper.ts
+++ b/servers/curated-corpus-api/src/test/helpers/createSectionHelper.ts
@@ -11,6 +11,7 @@ export interface CreateSectionHelperOptionalInput {
   scheduledSurfaceGuid?: ScheduledSurfacesEnum;
   iab?: IABMetadata,
   title?: string;
+  description?: string;
   active?: boolean;
   disabled?: boolean;
 }


### PR DESCRIPTION
## Goal
The `section-manager-lambda` passes an optional Section `description` to corpus-api

- **HNT-968**: Update `SqsSectionWithSectionItems` to add optional `description` (subtitle) property when ML creates/updates sections
- **HNT-969**: Update `createOrUpdateSection` to accept optional description property from the section-manager lambda

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-968
- https://mozilla-hub.atlassian.net/browse/HNT-969