### PR TITLE
fix(HNT-995): corpus item external image URLs get put in our S3 bucket

### DIFF
--- a/servers/curated-corpus-api/src/admin/aws/upload.integration.ts
+++ b/servers/curated-corpus-api/src/admin/aws/upload.integration.ts
@@ -1,9 +1,13 @@
-import { uploadImageToS3 } from './upload';
+import {
+  getS3UrlForImageUrl,
+  uploadImageToS3FromUrl,
+  uploadImageToS3,
+} from './upload';
+import * as Utils from './utils';
 import s3 from './s3';
 import Upload from 'graphql-upload/Upload.js';
 import { createReadStream, unlinkSync, writeFileSync } from 'fs';
 import config from '../../config';
-import { ApprovedItemS3ImageUrl } from '../../shared/types';
 
 const testFilePath = __dirname + '/test-image.jpeg';
 
@@ -13,31 +17,160 @@ export const integrationTestsS3UrlPattern = new RegExp(
   `^http://localhost?/${config.aws.s3.bucket}/.+.(jpeg|png)$`,
 );
 
-function expectSuccessfulUpload(upload: ApprovedItemS3ImageUrl) {
+function expectSuccessfulUpload(url: string) {
   // Check that the returned url matches the expected pattern
   // http://localstack:4566/curated-corpus-api-local-images/some-random-path.jpeg
-  expect(upload.url).toMatch(integrationTestsS3UrlPattern);
+  expect(url).toMatch(integrationTestsS3UrlPattern);
 }
 
 describe('Upload', () => {
-  beforeEach(() => {
-    writeFileSync(testFilePath, 'I am an image');
+  describe('uploadImageToS3', () => {
+    beforeEach(() => {
+      writeFileSync(testFilePath, 'I am an image');
+    });
+
+    afterEach(() => {
+      unlinkSync(testFilePath);
+    });
+
+    it('uploads an image to s3 using graphql Upload type', async () => {
+      const image: Upload = {
+        filename: 'test.jpeg',
+        mimetype: 'image/jpeg',
+        encoding: '7bit',
+        createReadStream: () => createReadStream(testFilePath),
+      };
+
+      const upload = await uploadImageToS3(s3, image);
+
+      expectSuccessfulUpload(upload.url);
+    });
   });
 
-  afterEach(() => {
-    unlinkSync(testFilePath);
+  describe('uploadImageToS3FromUrl', () => {
+    it('uploads an image to s3 using a URL with a valid content-type', async () => {
+      // mock function to control response of fetching remote image
+      const spy = jest
+        .spyOn(Utils, 'fetchImageFromUrl')
+        .mockImplementation(async () => {
+          const response = {
+            headers: new Headers({
+              // this is all that really matters in this mock
+              'Content-Type': 'image/png',
+            }),
+            body: 'fakeimagebody',
+          } as any as Response;
+
+          return Promise.resolve(response);
+        });
+
+      const upload = await uploadImageToS3FromUrl(
+        s3,
+        'https://some.external.domain/image.jpg',
+      );
+
+      expectSuccessfulUpload(upload.url);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      jest.restoreAllMocks();
+    });
+
+    it('fails to upload an image to s3 using a URL with an invalid content-type', async () => {
+      // mock function to control response of fetching remote image
+      const spy = jest
+        .spyOn(Utils, 'fetchImageFromUrl')
+        .mockImplementation(async () => {
+          const response = {
+            headers: new Headers({
+              // this is all that really matters in this mock
+              'Content-Type': 'text/javascript',
+            }),
+            body: 'someMaliciousJs',
+          } as any as Response;
+
+          return Promise.resolve(response);
+        });
+
+      await expect(
+        uploadImageToS3FromUrl(s3, 'https://some.external.domain/image.jpg'),
+      ).rejects.toThrow(
+        new Error(
+          `Unknown/unexpected content-type for image: https://some.external.domain/image.jpg`,
+        ),
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      jest.restoreAllMocks();
+    });
   });
 
-  it('uploads an image to s3 using graphql Upload type', async () => {
-    const image: Upload = {
-      filename: 'test.jpeg',
-      mimetype: 'image/jpeg',
-      encoding: '7bit',
-      createReadStream: () => createReadStream(testFilePath),
-    };
+  describe('getS3UrlForImageUrl', () => {
+    it('should return the given URL if it is already in our S3 bucket', async () => {
+      const inputUrl =
+        'http://localhost:4566/curated-corpus-api-local-images/fakeimage.png';
+      const url = await getS3UrlForImageUrl(s3, inputUrl);
 
-    const upload = await uploadImageToS3(s3, image);
+      // we should get the exact same URL back, as the URL is already in our
+      // S3 bucket
+      expect(url).toEqual(inputUrl);
+    });
 
-    expectSuccessfulUpload(upload);
+    it('should upload the image to S3 and return that URL if the given image is not already in our S3 bucket', async () => {
+      // mock function to control response of fetching remote image
+      const spy = jest
+        .spyOn(Utils, 'fetchImageFromUrl')
+        .mockImplementation(async () => {
+          const response = {
+            headers: new Headers({
+              // this is all that really matters in this mock
+              'Content-Type': 'image/png',
+            }),
+            body: 'fakeimagebody',
+          } as any as Response;
+
+          return Promise.resolve(response);
+        });
+
+      const url = await getS3UrlForImageUrl(
+        s3,
+        'https://some.external.domain/image.jpg',
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      expectSuccessfulUpload(url);
+
+      jest.restoreAllMocks();
+    });
+
+    it('should return null if the external source URL is not an image', async () => {
+      // mock function to control response of fetching remote image
+      const spy = jest
+        .spyOn(Utils, 'fetchImageFromUrl')
+        .mockImplementation(async () => {
+          const response = {
+            headers: new Headers({
+              // this is all that really matters in this mock
+              'Content-Type': 'text/javascript',
+            }),
+            body: 'someMaliciousJs',
+          } as any as Response;
+
+          return Promise.resolve(response);
+        });
+
+      const url = await getS3UrlForImageUrl(
+        s3,
+        'https://some.external.domain/image.jpg',
+      );
+
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      expect(url).toBeNull();
+
+      jest.restoreAllMocks();
+    });
   });
 });

--- a/servers/curated-corpus-api/src/admin/aws/upload.ts
+++ b/servers/curated-corpus-api/src/admin/aws/upload.ts
@@ -6,8 +6,95 @@ import { Upload as AWSUpload } from '@aws-sdk/lib-storage';
 import config from '../../config';
 import Upload from 'graphql-upload/Upload.js';
 import { ApprovedItemS3ImageUrl } from '../../shared/types';
+import { fetchImageFromUrl } from './utils';
 
 /**
+ * if the given imageUrl is in our S3 bucket, return that url. otherwise,
+ * copy the image from the given imageUrl into our S3 bucket and return
+ * the resulting S3 url.
+ *
+ * this function is used when creating an approved item. if an approved item is
+ * being managed from the admin tool, the image will already be in S3. if
+ * being managed via ML, the image may point to the third party publisher URL.
+ *
+ * @param s3 AWS S3 client
+ * @param imageUrl string
+ * @returns the S3 image URL, or null if the upload to S3 fails
+ */
+export async function getS3UrlForImageUrl(
+  s3: S3Client,
+  imageUrl: string,
+): Promise<string | null> {
+  let s3ImageUrl;
+
+  if (imageUrl.startsWith(config.aws.s3.path)) {
+    // if the imageUrl is already in our S3 bucket, no more processing needed
+    s3ImageUrl = imageUrl;
+  } else {
+    // try to upload the image to S3
+    try {
+      const upload: ApprovedItemS3ImageUrl = await uploadImageToS3FromUrl(
+        s3,
+        imageUrl,
+      );
+
+      s3ImageUrl = upload.url;
+    } catch (err) {
+      s3ImageUrl = null;
+    }
+  }
+
+  return s3ImageUrl;
+}
+
+/**
+ * uploads an image at the given imageUrl to our S3 bucket. this function is
+ * called from the createApprovedItem mutation when passed an image URL that is
+ * external/from a publisher (e.g. not in our S3 bucket).
+ *
+ * @param s3 AWS S3 client
+ * @param imageUrl string
+ * @returns ApprovedItemS3ImageUrl
+ */
+export async function uploadImageToS3FromUrl(
+  s3: S3Client,
+  imageUrl: string,
+): Promise<ApprovedItemS3ImageUrl> {
+  const imageResponse: Response = await fetchImageFromUrl(imageUrl);
+  const contentType = imageResponse.headers.get('content-type') ?? undefined;
+
+  // make sure we have an image
+  if (contentType === undefined || !contentType.startsWith('image/')) {
+    throw new Error(`Unknown/unexpected content-type for image: ${imageUrl}`);
+  }
+
+  const key = `${uuidv4()}.${mime.extension(contentType)}`;
+
+  const upload = new AWSUpload({
+    client: s3,
+    params: {
+      Bucket: config.aws.s3.bucket,
+      Key: key,
+      Body: imageResponse.body,
+      ContentType: contentType,
+      ACL: 'public-read',
+    },
+  });
+
+  const uploadResponse = await upload.done();
+
+  return {
+    url:
+      'Location' in uploadResponse // optional return parameter
+        ? uploadResponse.Location
+        : `${config.aws.s3.path}${key}`,
+  };
+}
+
+/**
+ * this function is called from the admin tool when uploading an image and
+ * *before* creating/updating the approved item
+ *
  * @param s3
  * @param image
  */

--- a/servers/curated-corpus-api/src/admin/aws/utils.ts
+++ b/servers/curated-corpus-api/src/admin/aws/utils.ts
@@ -22,3 +22,13 @@ export function checkValidImageContentType(contentType: string): boolean {
 
   return true;
 }
+
+/**
+ * wrapper function for fetch so we can mock easily in tests
+ *
+ * @param imageUrl string
+ * @returns Response
+ */
+export async function fetchImageFromUrl(imageUrl: string): Promise<Response> {
+  return await fetch(imageUrl);
+}

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/auth.integration.ts
@@ -2,6 +2,8 @@ import { print } from 'graphql';
 import request from 'supertest';
 import { ApolloServer } from '@apollo/server';
 import { PrismaClient } from '.prisma/client';
+
+import config from '../../../../config';
 import { client } from '../../../../database/client';
 
 import {
@@ -19,7 +21,11 @@ import {
 } from 'content-common';
 import { ACCESS_DENIED_ERROR } from '../../../../shared/types';
 import { MozillaAccessGroup } from 'content-common';
-import { clearDb, createApprovedItemHelper, createScheduledItemHelper } from '../../../../test/helpers';
+import {
+  clearDb,
+  createApprovedItemHelper,
+  createScheduledItemHelper,
+} from '../../../../test/helpers';
 import {
   CREATE_APPROVED_ITEM,
   REJECT_APPROVED_ITEM,
@@ -36,7 +42,8 @@ describe('mutations: ApprovedItem - authentication checks', () => {
   let server: ApolloServer<IAdminContext>;
   let graphQLUrl: string;
   let db: PrismaClient;
-  const rejectApprovedItemForDomainEndpoint = '/admin/reject-approved-corpus-items-for-domain';
+  const rejectApprovedItemForDomainEndpoint =
+    '/admin/reject-approved-corpus-items-for-domain';
 
   beforeAll(async () => {
     // port 0 tells express to dynamically assign an available port
@@ -65,7 +72,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
       { name: 'Jane Austen', sortOrder: 2 },
     ],
     status: CuratedStatus.CORPUS,
-    imageUrl: 'https://test.com/image.png',
+    imageUrl: `${config.aws.s3.path}/image.png`,
     language: CorpusLanguage.DE,
     publisher: 'Convective Cloud',
     datePublished: '2024-01-02',
@@ -192,7 +199,7 @@ describe('mutations: ApprovedItem - authentication checks', () => {
         excerpt: 'Updated excerpt',
         authors,
         status: CuratedStatus.CORPUS,
-        imageUrl: 'https://test.com/image.png',
+        imageUrl: `${config.aws.s3.path}/image.png`,
         language: CorpusLanguage.DE,
         publisher: 'Cloud Factory',
         datePublished: '2024-02-22',
@@ -444,22 +451,22 @@ describe('mutations: ApprovedItem - authentication checks', () => {
         title: '15 Unheard Ways To Achieve Greater Terraform',
         status: CuratedStatus.RECOMMENDATION,
         language: 'EN',
-        url: "https://elpais.com/example-one/"
+        url: 'https://elpais.com/example-one/',
       });
       // create a scheduled entry for item1
       await createScheduledItemHelper(db, {
-        approvedItem: item1
+        approvedItem: item1,
       });
 
       const item2 = await createApprovedItemHelper(db, {
         title: '16 Unheard Ways To Achieve Greater Terraform',
         status: CuratedStatus.RECOMMENDATION,
         language: 'EN',
-        url: "https://elpais.com/example-two/"
+        url: 'https://elpais.com/example-two/',
       });
       // create a scheduled entry for item2
       await createScheduledItemHelper(db, {
-        approvedItem: item2
+        approvedItem: item2,
       });
 
       // expect 2 approved corpus items

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/updateApprovedCorpusItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/updateApprovedCorpusItem.integration.ts
@@ -12,6 +12,9 @@ import {
   Topics,
 } from 'content-common';
 
+import * as Utils from '../../../aws/utils';
+
+import config from '../../../../config';
 import { client } from '../../../../database/client';
 
 import { clearDb, createApprovedItemHelper } from '../../../../test/helpers';
@@ -78,7 +81,7 @@ describe('mutations: ApprovedItem (updateApprovedCorpusItem)', () => {
       excerpt: 'Updated excerpt',
       authors,
       status: CuratedStatus.CORPUS,
-      imageUrl: 'https://test.com/image.png',
+      imageUrl: `${config.aws.s3.path}/image.png`,
       language: CorpusLanguage.DE,
       publisher: 'Cloud Factory',
       datePublished: '2024-02-24',
@@ -405,5 +408,82 @@ describe('mutations: ApprovedItem (updateApprovedCorpusItem)', () => {
     expect(result.body.errors).toBeUndefined();
     const data = result.body.data;
     expect(data.updateApprovedCorpusItem.language).toEqual('FR');
+  });
+
+  it('should succeed if provided image URL is external', async () => {
+    // mock function to control response of fetching remote image
+    const spy = jest
+      .spyOn(Utils, 'fetchImageFromUrl')
+      .mockImplementation(async () => {
+        const response = {
+          headers: new Headers({
+            // this is all that really matters in this mock
+            'Content-Type': 'image/png',
+          }),
+          body: 'fakeimagebody',
+        } as any as Response;
+
+        return Promise.resolve(response);
+      });
+
+    input.imageUrl = 'https://some.external.domain/image.jpg';
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_APPROVED_ITEM),
+        variables: { data: input },
+      });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body.data).not.toBeNull();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.body.data?.updateApprovedCorpusItem.imageUrl).toContain(
+      config.aws.s3.bucket,
+    );
+
+    jest.restoreAllMocks();
+  });
+
+  it('should fail if provided external image URL cannot be uploaded', async () => {
+    // mock function to control response of fetching remote image
+    const spy = jest
+      .spyOn(Utils, 'fetchImageFromUrl')
+      .mockImplementation(async () => {
+        const response = {
+          headers: new Headers({
+            // this is all that really matters in this mock
+            'Content-Type': 'text/javascript',
+          }),
+          body: 'someMaliciousJs',
+        } as any as Response;
+
+        return Promise.resolve(response);
+      });
+
+    input.imageUrl = 'https://some.external.domain/image.jpg';
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_APPROVED_ITEM),
+        variables: { data: input },
+      });
+
+    expect(result.body.data).toBeNull();
+    expect(result.body.errors).not.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // And there is the right error from the resolvers
+    expect(result.body.errors?.[0].message).toContain(
+      `Could not generate an S3 URL for the given image: ${input.imageUrl}`,
+    );
+    expect(result.body.errors?.[0].extensions?.code).toEqual('BAD_USER_INPUT');
+
+    jest.restoreAllMocks();
   });
 });


### PR DESCRIPTION
## Goal

ensures external image URLs provided when attempting to create or update an ApprovedCorpusItem are first copied into our S3 bucket.

- fixes an issue when ML is supplying external image URLs for corpus items

verified ML sections payloads are processed successfully on dev. also verified create/update functionality continues to work in the admin tool.

## Implementation Decisions

- targeted the `createApprovedCorpusItem` and `updateApprovedCorpusItem` mutations instead of the upstream lambdas to consolidate functionality in a single place, and account for any future ML payload data flows. (note - at this time, `updateApprovedCorpusItem` is never being called anywhere other than from the admin tool, but it seemed pertinent to add this check for potential future usage.)

## Deployment steps

- [x] Deployed to dev?

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-995
