### PR TITLE
HNT-1059: Compute SectionStatus to use Sections local timezone

### DIFF
--- a/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
+++ b/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
@@ -2,22 +2,31 @@ import { DateTime } from 'luxon';
 import { computeSectionStatus } from './SectionStatus';
 import { SectionStatus } from '../../types';
 
-describe('computeSectionStatus', () => {
-  let mockNow: DateTime;
+const testSurfacesTimeZones = [
+  { guid: 'NEW_TAB_EN_US',   timezone: 'America/New_York' },
+  { guid: 'NEW_TAB_DE_DE',   timezone: 'Europe/Berlin' },
+  { guid: 'NEW_TAB_EN_GB',   timezone: 'Europe/London' },
+  { guid: 'NEW_TAB_FR_FR',   timezone: 'Europe/Paris' },
+  { guid: 'NEW_TAB_IT_IT',   timezone: 'Europe/Rome' },
+  { guid: 'NEW_TAB_ES_ES',   timezone: 'Europe/Madrid' },
+  { guid: 'NEW_TAB_EN_INTL', timezone: 'Asia/Kolkata' },
+];
+describe.each(testSurfacesTimeZones)(
+  'computeSectionStatus – %s',
+  ({ guid, timezone }) => {
+    beforeEach(() => {
+      const mockNowLocal = DateTime.fromISO('2024-06-15T00:00:00', { zone: timezone }).startOf('day');
+      jest.spyOn(DateTime, 'now').mockReturnValue(mockNowLocal);
+    });
 
-  beforeEach(() => {
-    // Mock the current date to 2024-06-15 for consistent testing
-    mockNow = DateTime.fromISO('2024-06-15T12:00:00Z', { zone: 'utc' });
-    jest.spyOn(DateTime, 'utc').mockReturnValue(mockNow);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
   describe('DISABLED status', () => {
     it('should return DISABLED when disabled flag is true, regardless of dates', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: true,
         startDate: new Date('2024-06-01'),
         endDate: new Date('2024-06-30'),
@@ -28,6 +37,7 @@ describe('computeSectionStatus', () => {
 
     it('should return DISABLED even with future startDate', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: true,
         startDate: new Date('2024-07-01'),
         endDate: new Date('2024-07-31'),
@@ -38,6 +48,7 @@ describe('computeSectionStatus', () => {
 
     it('should return DISABLED even with past endDate', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: true,
         startDate: new Date('2024-05-01'),
         endDate: new Date('2024-05-31'),
@@ -50,6 +61,7 @@ describe('computeSectionStatus', () => {
   describe('SCHEDULED status', () => {
     it('should return SCHEDULED when startDate is in the future and not disabled', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-07-01'),
         endDate: new Date('2024-07-31'),
@@ -60,6 +72,7 @@ describe('computeSectionStatus', () => {
 
     it('should return SCHEDULED for future startDate with no endDate', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-07-01'),
         endDate: null,
@@ -72,9 +85,10 @@ describe('computeSectionStatus', () => {
   describe('EXPIRED status', () => {
     it('should return EXPIRED when currentDate >= endDate', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-05-01'),
-        endDate: new Date('2024-06-15'), // Same as current date
+        endDate: new Date('2024-06-14'), // Same as current date
       };
 
       expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
@@ -82,6 +96,7 @@ describe('computeSectionStatus', () => {
 
     it('should return EXPIRED when endDate is in the past', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-05-01'),
         endDate: new Date('2024-06-14'), // Day before current date
@@ -94,6 +109,7 @@ describe('computeSectionStatus', () => {
   describe('LIVE status', () => {
     it('should return LIVE when startDate <= currentDate < endDate', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-06-01'),
         endDate: new Date('2024-06-30'),
@@ -104,6 +120,7 @@ describe('computeSectionStatus', () => {
 
     it('should return LIVE when startDate <= currentDate and endDate is null', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-06-01'),
         endDate: null,
@@ -114,6 +131,7 @@ describe('computeSectionStatus', () => {
 
     it('should return LIVE when startDate is today', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: new Date('2024-06-15'),
         endDate: new Date('2024-06-30'),
@@ -124,6 +142,7 @@ describe('computeSectionStatus', () => {
 
     it('should return LIVE for ML sections (no startDate) when not disabled', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: null,
         endDate: null,
@@ -134,6 +153,7 @@ describe('computeSectionStatus', () => {
 
     it('should return LIVE for sections without dates when not disabled', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
       };
 
@@ -144,6 +164,7 @@ describe('computeSectionStatus', () => {
   describe('edge cases', () => {
     it('should handle undefined dates correctly', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
         startDate: undefined,
         endDate: undefined,
@@ -152,15 +173,14 @@ describe('computeSectionStatus', () => {
       expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
     });
 
-    it('should handle timezones correctly by normalizing to UTC start of day', () => {
-      // Create dates with specific times
+    it('should return LIVE when current local day is within start and end date range', () => {
       const section = {
+        scheduledSurfaceGuid: guid,
         disabled: false,
-        startDate: new Date('2024-06-15T23:59:59Z'), // Late on the 15th
-        endDate: new Date('2024-06-16T00:00:01Z'), // Early on the 16th
+        startDate: new Date('2024-06-15T00:00:00Z'),
+        endDate: new Date('2024-06-16T00:00:00Z'),
       };
 
-      // Both should be normalized to start of their respective days
       expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
     });
   });

--- a/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.ts
+++ b/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.ts
@@ -1,20 +1,33 @@
 import { DateTime } from 'luxon';
 import { SectionStatus } from '../../types';
+import { ScheduledSurfaces } from 'content-common';
 
 interface Section {
+  scheduledSurfaceGuid: string;
   disabled: boolean;
   startDate?: Date | null;
   endDate?: Date | null;
 }
 
 /**
- * Compute the status of a Section dynamically based on:
- * - disabled flag
- * - startDate
- * - endDate
+ * Dynamically compute the status of a Section based on:
+ * - its `disabled` flag
+ * - its `startDate` and `endDate`
+ * - the current local time in the section's scheduled surface timezone
+ *
+ * Timezones matter: the "current day" is evaluated in the section's local time,
+ * not in UTC.
  */
 export function computeSectionStatus(section: Section): SectionStatus {
-  const currentDate = DateTime.utc().startOf('day'); // Normalize to 00:00 UTC
+  // 1. Look up the timezone from the section's scheduled surface
+  const scheduledSurface = ScheduledSurfaces.find(
+    (s) => s.guid === section.scheduledSurfaceGuid
+  );
+  // Fallback to UTC if the surface doesn't have a configured timezone
+  const timeZone = scheduledSurface?.ianaTimezone || 'UTC';
+
+  // Normalize current time to the start of day in the section's local timezone
+  const currentDate = DateTime.now().setZone(timeZone).startOf('day');
 
   // 1. DISABLED flag is true, overrides everything
   if (section.disabled) {
@@ -23,23 +36,30 @@ export function computeSectionStatus(section: Section): SectionStatus {
 
   // 2. If section has a startDate (custom section logic)
   if (section.startDate) {
-    const startDate = DateTime.fromJSDate(section.startDate, { zone: 'utc' }).startOf('day');
+    const startDate = DateTime.fromJSDate(section.startDate).setZone(timeZone).startOf('day');
 
     // a. SCHEDULED: disabled flag is false AND startDate is in the future
     if (startDate > currentDate) {
       return SectionStatus.SCHEDULED;
     }
 
-    // b. EXPIRED: disabled is false AND currentDate >= endDate
+    // b. EXPIRED: disabled is false & section's endDate has passed (inclusive of full endDate)
     if (section.endDate) {
-      const endDate = DateTime.fromJSDate(section.endDate, { zone: 'utc' }).startOf('day');
-      if (currentDate >= endDate) {
+      const endDateExclusive = DateTime.fromJSDate(section.endDate)
+        .setZone(timeZone)
+        .startOf('day')
+        .plus({ days: 1 });
+
+      if (currentDate >= endDateExclusive) {
         return SectionStatus.EXPIRED;
       }
     }
 
-    // c. LIVE: disabled is false AND startDate <= currentDate AND (endDate is null OR currentDate < endDate)
-    if (startDate <= currentDate && (!section.endDate || currentDate < DateTime.fromJSDate(section.endDate, { zone: 'utc' }).startOf('day'))) {
+    // c. LIVE: disabled is false AND startDate <= currentDate AND (endDate is null OR currentDate < endDate (inclusive of full endDate))
+    if (
+      startDate <= currentDate &&
+      (!section.endDate || currentDate < DateTime.fromJSDate(section.endDate).setZone(timeZone).endOf('day').plus({ days: 1 }))
+    ) {
       return SectionStatus.LIVE;
     }
   }


### PR DESCRIPTION
## Goal

Use the `ianaTimezone` based on the scheduled surface of the Section to normalize the `startDate` & `endDate`.

- use `startOf(day)` for `startDate` (midnight local timezone)
- use `enfOd(day)` for `endDate` to expire Section through the `endDate`, not in the beginning of `endDate`

## Deployment steps

- [ ] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-1059
