### PR TITLE
HNT-1114: fix section status computation

### DIFF
--- a/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
+++ b/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
@@ -14,7 +14,7 @@ const testSurfacesTimeZones = [
 describe.each(testSurfacesTimeZones)(
   'computeSectionStatus – %s',
   ({ guid, timezone }) => {
-    
+
     beforeEach(() => {
       const mockNowLocal = DateTime.fromISO('2024-06-15T00:00:00', { zone: timezone }).startOf('day');
       jest.spyOn(DateTime, 'now').mockReturnValue(mockNowLocal);
@@ -24,176 +24,198 @@ describe.each(testSurfacesTimeZones)(
       jest.restoreAllMocks();
     });
 
-  describe('DISABLED status', () => {
-    it('should return DISABLED when disabled flag is true, regardless of dates', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: true,
-        startDate: new Date('2024-06-01'),
-        endDate: new Date('2024-06-30'),
-      };
+    describe('DISABLED status', () => {
+      it('should return DISABLED when disabled flag is true, regardless of dates', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: true,
+          startDate: new Date('2024-06-01'),
+          endDate: new Date('2024-06-30'),
+        };
 
-      expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+        expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+      });
+
+      it('should return DISABLED even with future startDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: true,
+          startDate: new Date('2024-07-01'),
+          endDate: new Date('2024-07-31'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+      });
+
+      it('should return DISABLED even with past endDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: true,
+          startDate: new Date('2024-05-01'),
+          endDate: new Date('2024-05-31'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+      });
     });
 
-    it('should return DISABLED even with future startDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: true,
-        startDate: new Date('2024-07-01'),
-        endDate: new Date('2024-07-31'),
-      };
+    describe('SCHEDULED status', () => {
+      it('should return SCHEDULED when startDate is the next day after currentDate and not disabled', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-16'),
+          endDate: new Date('2024-07-31'),
+        };
 
-      expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+        expect(computeSectionStatus(section)).toBe(SectionStatus.SCHEDULED);
+      });
+
+      it('should return SCHEDULED when startDate is in the future and not disabled', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-07-01'),
+          endDate: new Date('2024-07-31'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.SCHEDULED);
+      });
+
+      it('should return SCHEDULED for future startDate with no endDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-07-01'),
+          endDate: null,
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.SCHEDULED);
+      });
     });
 
-    it('should return DISABLED even with past endDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: true,
-        startDate: new Date('2024-05-01'),
-        endDate: new Date('2024-05-31'),
-      };
+    describe('EXPIRED status', () => {
+      it('should return EXPIRED when currentDate >= endDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-05-01'),
+          endDate: new Date('2024-06-14'), // Same as current date
+        };
 
-      expect(computeSectionStatus(section)).toBe(SectionStatus.DISABLED);
+        expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
+      });
+
+      it('should return EXPIRED when endDate is in the past', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-05-01'),
+          endDate: new Date('2024-06-14'), // Day before current date
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
+      });
+
+      it('should return EXPIRED when endDate is right before the currentDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-14'),
+          endDate: new Date('2024-06-12'), // Day before current date
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
+      });
+    });
+
+    describe('LIVE status', () => {
+      it('should return LIVE when startDate <= currentDate < endDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-01'),
+          endDate: new Date('2024-06-30'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE when startDate <= currentDate and endDate is null', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-01'),
+          endDate: null,
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE when startDate is today', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-15'),
+          endDate: new Date('2024-06-30'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE for ML sections (no startDate) when not disabled', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: null,
+          endDate: null,
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE for sections without dates when not disabled', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle undefined dates correctly', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: undefined,
+          endDate: undefined,
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE when current local day is within start and end date range', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-15T00:00:00Z'),
+          endDate: new Date('2024-06-16T00:00:00Z'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
+
+      it('should return LIVE when startDate and endDate are the same and match currentDate', () => {
+        const section = {
+          scheduledSurfaceGuid: guid,
+          disabled: false,
+          startDate: new Date('2024-06-15T00:00:00-04:00'),
+          endDate: new Date('2024-06-15T00:00:00-04:00'),
+        };
+
+        expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
+      });
     });
   });
-
-  describe('SCHEDULED status', () => {
-    it('should return SCHEDULED when startDate is in the future and not disabled', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-07-01'),
-        endDate: new Date('2024-07-31'),
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.SCHEDULED);
-    });
-
-    it('should return SCHEDULED for future startDate with no endDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-07-01'),
-        endDate: null,
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.SCHEDULED);
-    });
-  });
-
-  describe('EXPIRED status', () => {
-    it('should return EXPIRED when currentDate >= endDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-05-01'),
-        endDate: new Date('2024-06-14'), // Same as current date
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
-    });
-
-    it('should return EXPIRED when endDate is in the past', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-05-01'),
-        endDate: new Date('2024-06-14'), // Day before current date
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.EXPIRED);
-    });
-  });
-
-  describe('LIVE status', () => {
-    it('should return LIVE when startDate <= currentDate < endDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-06-01'),
-        endDate: new Date('2024-06-30'),
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE when startDate <= currentDate and endDate is null', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-06-01'),
-        endDate: null,
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE when startDate is today', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-06-15'),
-        endDate: new Date('2024-06-30'),
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE for ML sections (no startDate) when not disabled', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: null,
-        endDate: null,
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE for sections without dates when not disabled', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle undefined dates correctly', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: undefined,
-        endDate: undefined,
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE when current local day is within start and end date range', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-06-15T00:00:00Z'),
-        endDate: new Date('2024-06-16T00:00:00Z'),
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-
-    it('should return LIVE when startDate and endDate are the same and match currentDate', () => {
-      const section = {
-        scheduledSurfaceGuid: guid,
-        disabled: false,
-        startDate: new Date('2024-06-15T00:00:00-04:00'),
-        endDate: new Date('2024-06-15T00:00:00-04:00'),
-      };
-
-      expect(computeSectionStatus(section)).toBe(SectionStatus.LIVE);
-    });
-  });
-});

--- a/servers/curated-corpus-api/src/shared/utils.spec.ts
+++ b/servers/curated-corpus-api/src/shared/utils.spec.ts
@@ -1,5 +1,5 @@
 import { CorpusItemSource, CuratedStatus, Topics } from 'content-common';
-
+import { DateTime } from 'luxon';
 import { MozillaAccessGroup } from 'content-common';
 import {
   getCorpusItemFromApprovedItem,
@@ -8,10 +8,34 @@ import {
   toUtcDateString,
   getPocketPath,
   getNormalizedDomainName,
+  getLocalDate,
 } from './utils';
 import { ApprovedItem } from '../database/types';
 
 describe('shared/utils', () => {
+  // Timezones to test
+  const timezones = [
+    'UTC',
+    'America/New_York',
+    'Europe/Berlin',
+    'Europe/London',
+    'Europe/Paris',
+    'Europe/Rome',
+    'Europe/Madrid',
+    'Asia/Kolkata',
+  ];
+  describe.each(timezones)('getLocalDate in %s', (tz) => {
+    it('should return midnight of the same calendar day in the given timezone', () => {
+      const input = new Date('2024-06-15T12:30:56Z'); // noon UTC
+      const result = getLocalDate(input, tz);
+      
+      const expected = DateTime.fromJSDate(input)
+        .setZone(tz)
+        .startOf('day');
+
+      expect(result.toISO()).toBe(expected.toISO());
+    });
+  });
   describe('toUtcDateString', () => {
     it('should convert to YYYY-MM-DD UTC for zero-padded months', async () => {
       const date = new Date(1647042571000); // 2022-03-11 23:49:31 UTC

--- a/servers/curated-corpus-api/src/shared/utils.ts
+++ b/servers/curated-corpus-api/src/shared/utils.ts
@@ -2,6 +2,7 @@ import { ScheduledSurface, ScheduledSurfaces } from 'content-common';
 import { ApprovedItem, CorpusItem, CorpusTargetType } from '../database/types';
 import { ApprovedItemAuthor } from 'content-common';
 import { parse } from 'url';
+import { DateTime } from 'luxon';
 
 /**
  * Generate an integer Epoch time from a JavaScript Date object.
@@ -231,4 +232,23 @@ export function reorderResultByKey<T, K extends keyof T>(
   }, {} as any); // idk... help me with this index type
 
   return reorderMap.values.map((input) => resMap[input]);
+}
+
+/**
+ * Convert JS Date → Luxon DateTime in the section's local timezone,
+ * treating the JS Date as a plain calendar date (not a UTC timestamp).
+ * JS Date months are 0-based (January = 0), but Luxon expects 1-based months.
+ * So we must add 1 to `getMonth()` to get the correct calendar month.
+ * @param date JS Date object
+ * @param timeZone IANA time zone string (e.g., "America/New_York")
+ */
+export function getLocalDate(date: Date, timeZone: string): DateTime {
+  return DateTime.fromObject(
+    {
+      year: date.getFullYear(),
+      month: date.getMonth() + 1, // JS months are 0-based; Luxon expects 1-based
+      day: date.getDate(),
+    },
+    { zone: timeZone }
+  ).startOf('day');
 }


### PR DESCRIPTION
## Goal

Sections scheduled with a `startDate` one day after the `currentDate` were incorrectly evaluated as `LIVE` instead of `SCHEDULED`  — but only in certain timezones (e.g. America/New_York).

This happened because we were using `DateTime.fromJSDate()` to convert `Date` objects to Luxon `DateTime`, which treats the original date as midnight in UTC, not in the intended local timezone. As a result, a Date like **2024-06-16** was interpreted as **2024-06-15T20:00:00-04:00** in New York — shifting the effective date back by one day.

Convert `startDate` and `endDate` using `DateTime.fromObject()` instead of `fromJSDate()`. This ensures we always interpret the UI-selected date as a local calendar day.

## Deployment steps

- [x] Deployed to dev

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-1114
