### PR TITLE
HNT-1359: Add updateSectionItem mutation

### DIFF
--- a/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
+++ b/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
@@ -12,6 +12,7 @@ import {
   ActiveSectionItem,
   CreateSectionItemApiInput,
   CreateOrUpdateSectionApiInput,
+  UpdateSectionItemApiInput,
   RemoveSectionItemApiInput,
 } from './types';
 
@@ -65,6 +66,7 @@ export const createOrUpdateSection = async (
                 externalId
                 sectionItems {
                   externalId
+                  rank
                   approvedItem {
                     externalId
                     url
@@ -100,6 +102,7 @@ export const createOrUpdateSection = async (
     externalId: section.externalId,
     sectionItems: sectionItems.map((item: any) => ({
       externalId: item.externalId,
+      rank: item.rank,
       approvedItem: {
         externalId: item.approvedItem.externalId,
         url: item.approvedItem.url,
@@ -199,6 +202,55 @@ export async function createSectionItem(
   }
 
   return result.data.createSectionItem.externalId;
+}
+
+/**
+ * Calls the updateSectionItem mutation in curated-corpus-api. Updates
+ * mutable fields on a SectionItem (e.g. rank).
+ *
+ * @param adminApiEndpoint  string
+ * @param graphHeaders GraphQlApiHeaders object
+ * @param data UpdateSectionItemApiInput
+ * @returns Promise<string> - externalId of the updated SectionItem
+ */
+export async function updateSectionItem(
+  adminApiEndpoint: string,
+  graphHeaders: GraphQlApiCallHeaders,
+  data: UpdateSectionItemApiInput,
+): Promise<string> {
+  await sleep(config.app.graphQLSleep);
+
+  const mutation = `
+    mutation UpdateSectionItem($data: UpdateSectionItemInput!) {
+      updateSectionItem(data: $data) {
+        externalId
+      }
+    }`;
+
+  const variables = { data };
+
+  const res = await fetch(adminApiEndpoint, {
+    method: 'post',
+    headers: graphHeaders,
+    body: JSON.stringify({ query: mutation, variables }),
+  });
+
+  const result = await res.json();
+
+  console.log(`UpdateSectionItem MUTATION OUTPUT: ${JSON.stringify(result)}`);
+
+  // check for any errors returned by the mutation
+  if (!result.data && result.errors?.length > 0) {
+    throw new Error(
+      `updateSectionItem mutation failed: ${result.errors[0].message}`,
+    );
+  }
+
+  if (!result.data) {
+    throw new Error('updateSectionItem mutation returned no data');
+  }
+
+  return result.data.updateSectionItem.externalId;
 }
 
 /**

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -36,7 +36,7 @@ export interface SqsSectionItem {
 
 export interface ActiveSectionItem {
   externalId: string;
-  rank: number | null;
+  rank: number;
   approvedItem: {
     externalId: string;
     url: string;
@@ -62,7 +62,7 @@ export type CreateSectionItemApiInput = {
 
 export type UpdateSectionItemApiInput = {
   externalId: string;
-  rank?: number;
+  rank: number;
 };
 
 export type RemoveSectionItemApiInput = {

--- a/lambdas/section-manager-lambda/src/types.ts
+++ b/lambdas/section-manager-lambda/src/types.ts
@@ -36,6 +36,7 @@ export interface SqsSectionItem {
 
 export interface ActiveSectionItem {
   externalId: string;
+  rank: number | null;
   approvedItem: {
     externalId: string;
     url: string;
@@ -56,6 +57,11 @@ export type CreateOrUpdateSectionApiInput = {
 export type CreateSectionItemApiInput = {
   approvedItemExternalId: string;
   sectionExternalId: string;
+  rank?: number;
+};
+
+export type UpdateSectionItemApiInput = {
+  externalId: string;
   rank?: number;
 };
 

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -407,6 +407,7 @@ describe('utils', () => {
       const mockSectionItems = [
         {
           externalId: 'sectionItemExternalId1',
+          rank: 0,
           approvedItem: {
             externalId: 'approvedItemExternalId1',
             url: 'https://example-one.com',
@@ -414,6 +415,7 @@ describe('utils', () => {
         },
         {
           externalId: 'sectionItemExternalId2',
+          rank: 1,
           approvedItem: {
             externalId: 'approvedItemExternalId2',
             url: 'https://example-two.com',
@@ -579,16 +581,18 @@ describe('utils', () => {
         sectionItems: [
           {
             externalId: 'sectionItem1',
+            rank: 0,
             approvedItem: { externalId: 'approvedItem1', url: url1 },
           },
           {
             externalId: 'sectionItem2',
+            rank: 1,
             approvedItem: { externalId: 'approvedItem2', url: url2 },
           },
         ],
       });
 
-      // ML sends SectionItem payload with URL2 (already active) + URL3 (new)
+      // ML sends SectionItem payload with URL2 (already active, same rank) + URL3 (new)
       const sqs = createSqsSectionWithSectionItems({}, 0);
       sqs.candidates = [
         { url: url2, rank: 1 } as any,
@@ -631,6 +635,129 @@ describe('utils', () => {
           deactivateSource: 'ML',
         }),
       );
+    });
+
+    it('calls updateSectionItem when an existing item has a rank mismatch', async () => {
+      const url1 = 'https://example-one.com';
+      const url2 = 'https://example-two.com';
+
+      // Existing section has items with rank 0 and 1
+      mockCreateOrUpdateSection.mockResolvedValue({
+        externalId: 'sectionExternalId1',
+        sectionItems: [
+          {
+            externalId: 'sectionItem1',
+            rank: 0,
+            approvedItem: { externalId: 'approvedItem1', url: url1 },
+          },
+          {
+            externalId: 'sectionItem2',
+            rank: 1,
+            approvedItem: { externalId: 'approvedItem2', url: url2 },
+          },
+        ],
+      });
+
+      // ML sends the same URLs but with swapped ranks
+      const sqs = createSqsSectionWithSectionItems({}, 0);
+      sqs.candidates = [
+        { url: url1, rank: 1 } as any,
+        { url: url2, rank: 0 } as any,
+      ];
+
+      const mockUpdateSectionItem = jest
+        .spyOn(GraphQlApiCalls, 'updateSectionItem')
+        .mockResolvedValue('sectionItem1');
+
+      await Utils.processSqsSectionData(sqs, jwtBearerToken);
+
+      // No new items should be created (both URLs already exist)
+      expect(mockCreateSectionItem).not.toHaveBeenCalled();
+
+      // Both items should be updated since ranks changed
+      expect(mockUpdateSectionItem).toHaveBeenCalledTimes(2);
+      expect(mockUpdateSectionItem).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        { externalId: 'sectionItem1', rank: 1 },
+      );
+      expect(mockUpdateSectionItem).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Object),
+        { externalId: 'sectionItem2', rank: 0 },
+      );
+    });
+
+    it('skips updateSectionItem when an existing item rank matches', async () => {
+      const url1 = 'https://example-one.com';
+
+      // Existing section has item with rank 0
+      mockCreateOrUpdateSection.mockResolvedValue({
+        externalId: 'sectionExternalId1',
+        sectionItems: [
+          {
+            externalId: 'sectionItem1',
+            rank: 0,
+            approvedItem: { externalId: 'approvedItem1', url: url1 },
+          },
+        ],
+      });
+
+      // ML sends same URL with same rank
+      const sqs = createSqsSectionWithSectionItems({}, 0);
+      sqs.candidates = [{ url: url1, rank: 0 } as any];
+
+      const mockUpdateSectionItem = jest
+        .spyOn(GraphQlApiCalls, 'updateSectionItem')
+        .mockResolvedValue('sectionItem1');
+
+      await Utils.processSqsSectionData(sqs, jwtBearerToken);
+
+      // No creates, no updates
+      expect(mockCreateSectionItem).not.toHaveBeenCalled();
+      expect(mockUpdateSectionItem).not.toHaveBeenCalled();
+    });
+
+    it('continues processing if updateSectionItem fails for one item', async () => {
+      const url1 = 'https://example-one.com';
+      const url2 = 'https://example-two.com';
+
+      mockCreateOrUpdateSection.mockResolvedValue({
+        externalId: 'sectionExternalId1',
+        sectionItems: [
+          {
+            externalId: 'sectionItem1',
+            rank: 0,
+            approvedItem: { externalId: 'approvedItem1', url: url1 },
+          },
+          {
+            externalId: 'sectionItem2',
+            rank: 1,
+            approvedItem: { externalId: 'approvedItem2', url: url2 },
+          },
+        ],
+      });
+
+      // ML sends both URLs with changed ranks
+      const sqs = createSqsSectionWithSectionItems({}, 0);
+      sqs.candidates = [
+        { url: url1, rank: 5 } as any,
+        { url: url2, rank: 6 } as any,
+      ];
+
+      const mockUpdateSectionItem = jest
+        .spyOn(GraphQlApiCalls, 'updateSectionItem')
+        .mockRejectedValueOnce(new Error('Update failed'))
+        .mockResolvedValueOnce('sectionItem2');
+
+      await Utils.processSqsSectionData(sqs, jwtBearerToken);
+
+      // Both updates attempted
+      expect(mockUpdateSectionItem).toHaveBeenCalledTimes(2);
+
+      // One failure logged
+      expect(sentryStub).toHaveBeenCalledTimes(1);
+      expect(mockConsoleError).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -100,9 +100,9 @@ export const processSqsSectionData = async (
             externalId: existingItem.externalId,
             rank: sqsSectionItem.rank,
           });
-          successfulCandidates++;
         }
-        // Skip creation — item already exists (rank updated if needed)
+        // Count as successful whether rank was updated or already matched
+        successfulCandidates++;
         continue;
       }
 

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -23,6 +23,7 @@ import {
   createApprovedCorpusItem,
   createOrUpdateSection,
   createSectionItem,
+  updateSectionItem,
   getApprovedCorpusItemByUrl,
   removeSectionItem,
 } from './graphQlApiCalls';
@@ -65,9 +66,13 @@ export const processSqsSectionData = async (
 
   const sectionExternalId = sectionResult.externalId;
   const activeSectionItems = sectionResult.sectionItems || [];
-  // Get SectionItems URLs from existing active SectionItems
-  const activeSectionItemsUrlsSet = new Set(
-    activeSectionItems.map((item) => item.approvedItem.url),
+
+  // Build a map of URL -> { externalId, rank } for existing active items
+  const activeItemsByUrl = new Map(
+    activeSectionItems.map((item) => [
+      item.approvedItem.url,
+      { externalId: item.externalId, rank: item.rank },
+    ]),
   );
 
   // keep track of how many candidates succeeded, how many failed
@@ -85,11 +90,24 @@ export const processSqsSectionData = async (
     // convenience!
     const sqsSectionItem: SqsSectionItem = sqsSectionData.candidates[i];
     try {
-      let approvedItemExternalId: string;
-      // avoid creating SectionItem duplicates if the URL already exists
-      if (activeSectionItemsUrlsSet.has(sqsSectionItem.url)) {
+      // Check if URL already exists as an active SectionItem
+      const existingItem = activeItemsByUrl.get(sqsSectionItem.url);
+
+      if (existingItem) {
+        // URL exists — check if rank needs updating
+        if (existingItem.rank !== sqsSectionItem.rank) {
+          await updateSectionItem(config.adminApiEndpoint, graphHeaders, {
+            externalId: existingItem.externalId,
+            rank: sqsSectionItem.rank,
+          });
+          successfulCandidates++;
+        }
+        // Skip creation — item already exists (rank updated if needed)
         continue;
       }
+
+      let approvedItemExternalId: string;
+
       // see if the Corpus has an ApprovedItem matching the SectionItem's URL
       const approvedCorpusItem = await getApprovedCorpusItemByUrl(
         config.adminApiEndpoint,
@@ -117,15 +135,22 @@ export const processSqsSectionData = async (
 
       // call the mutation to createSectionItem using the ApprovedItem either
       // created or retrieved above
-      await createSectionItem(config.adminApiEndpoint, graphHeaders, {
-        approvedItemExternalId,
-        sectionExternalId,
-        rank: sqsSectionItem.rank,
-      });
+      const newSectionItemExternalId = await createSectionItem(
+        config.adminApiEndpoint,
+        graphHeaders,
+        {
+          approvedItemExternalId,
+          sectionExternalId,
+          rank: sqsSectionItem.rank,
+        },
+      );
       // Mark URL as active to prevent duplicate creation
       // ML should not be sending duplicate candidate URLs within a Section within the same run
       // this is a safe guard
-      activeSectionItemsUrlsSet.add(sqsSectionItem.url);
+      activeItemsByUrl.set(sqsSectionItem.url, {
+        externalId: newSectionItemExternalId,
+        rank: sqsSectionItem.rank,
+      });
       // update successful candidates count
       successfulCandidates++;
     } catch (e) {

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -152,7 +152,7 @@ export type CreateSectionItemApiInput = {
 
 export type UpdateSectionItemApiInput = {
   externalId: string;
-  rank?: number;
+  rank: number;
 };
 
 export type RemoveSectionItemApiInput = {

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -150,6 +150,11 @@ export type CreateSectionItemApiInput = {
   rank?: number;
 };
 
+export type UpdateSectionItemApiInput = {
+  externalId: string;
+  rank?: number;
+};
+
 export type RemoveSectionItemApiInput = {
   externalId: string;
   deactivateReasons: SectionItemRemovalReason[];

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -684,6 +684,20 @@ input CreateSectionItemInput {
 }
 
 """
+Input data for updating a SectionItem's mutable fields
+"""
+input UpdateSectionItemInput {
+  """
+  ID of the SectionItem. A string in UUID format.
+  """
+  externalId: ID!
+  """
+  The updated rank of the SectionItem in relation to its siblings.
+  """
+  rank: Int
+}
+
+"""
 Input data for removing a SectionItem
 """
 input RemoveSectionItemInput {
@@ -1391,6 +1405,11 @@ type Mutation {
   Creates a SectionItem within a Section.
   """
   createSectionItem(data: CreateSectionItemInput!): SectionItem!
+
+  """
+  Updates a SectionItem's mutable fields (e.g. rank).
+  """
+  updateSectionItem(data: UpdateSectionItemInput!): SectionItem!
 
   """
   Removes an active SectionItem from a Section.

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -694,7 +694,7 @@ input UpdateSectionItemInput {
   """
   The updated rank of the SectionItem in relation to its siblings.
   """
-  rank: Int
+  rank: Int!
 }
 
 """

--- a/servers/curated-corpus-api/src/admin/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/index.ts
@@ -37,7 +37,7 @@ import {
   deleteCustomSection,
   updateCustomSection,
 } from './mutations/Section';
-import { createSectionItem, removeSectionItem } from './mutations/SectionItem';
+import { createSectionItem, updateSectionItem, removeSectionItem } from './mutations/SectionItem';
 import { createOrUpdatePublisherDomain } from './mutations/PublisherDomain';
 import { computeSectionStatus } from '../../shared/resolvers/fields/SectionStatus';
 import { getUrlMetadata } from './queries/UrlMetadata';
@@ -140,6 +140,7 @@ export const resolvers = {
     createScheduleReview: createScheduleReview,
     createOrUpdateSection: createOrUpdateSection,
     createSectionItem: createSectionItem,
+    updateSectionItem: updateSectionItem,
     removeSectionItem: removeSectionItem,
     disableEnableSection: disableEnableSection,
     createCustomSection: createCustomSection,

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
@@ -1,7 +1,12 @@
-import { AuthenticationError, NotFoundError } from '@pocket-tools/apollo-utils';
+import {
+  AuthenticationError,
+  NotFoundError,
+  UserInputError,
+} from '@pocket-tools/apollo-utils';
 
 import {
   createSectionItem as dbCreateSectionItem,
+  updateSectionItem as dbUpdateSectionItem,
   removeSectionItem as dbRemoveSectionItem,
 } from '../../../../database/mutations';
 import { SectionItem } from '../../../../database/types';
@@ -71,6 +76,65 @@ export async function createSectionItem(
 
   context.emitSectionItemEvent(
     SectionItemEventType.ADD_SECTION_ITEM,
+    sectionItemForEvents,
+  );
+
+  return sectionItem;
+}
+
+/**
+ * Updates a SectionItem's mutable fields (e.g. rank).
+ *
+ * @param parent
+ * @param data
+ * @param context
+ */
+export async function updateSectionItem(
+  parent,
+  { data },
+  context: IAdminContext,
+): Promise<SectionItem> {
+  const { actionScreen, externalId, ...updateFields } = data;
+
+  // Validate at least one mutable field is provided
+  if (Object.keys(updateFields).length === 0) {
+    throw new UserInputError(
+      'At least one field to update must be provided.',
+    );
+  }
+
+  // Find the SectionItem and its parent Section for access control
+  const existingItem = await context.db.sectionItem.findUnique({
+    where: { externalId, active: true },
+    include: { section: true },
+  });
+
+  if (!existingItem) {
+    throw new NotFoundError(
+      `Cannot update a section item: Section item with id "${externalId}" does not exist.`,
+    );
+  }
+
+  const scheduledSurfaceGuid = existingItem.section.scheduledSurfaceGuid;
+
+  if (!context.authenticatedUser.canWriteToSurface(scheduledSurfaceGuid)) {
+    throw new AuthenticationError(ACCESS_DENIED_ERROR);
+  }
+
+  const sectionItem = await dbUpdateSectionItem(context.db, {
+    externalId,
+    ...updateFields,
+  });
+
+  const sectionItemForEvents: SectionItemPayload = {
+    sectionItem: {
+      ...sectionItem,
+      action_screen: actionScreen,
+    },
+  };
+
+  context.emitSectionItemEvent(
+    SectionItemEventType.UPDATE_SECTION_ITEM,
     sectionItemForEvents,
   );
 

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
@@ -1,8 +1,4 @@
-import {
-  AuthenticationError,
-  NotFoundError,
-  UserInputError,
-} from '@pocket-tools/apollo-utils';
+import { AuthenticationError, NotFoundError } from '@pocket-tools/apollo-utils';
 
 import {
   createSectionItem as dbCreateSectionItem,
@@ -94,14 +90,7 @@ export async function updateSectionItem(
   { data },
   context: IAdminContext,
 ): Promise<SectionItem> {
-  const { actionScreen, externalId, ...updateFields } = data;
-
-  // Validate at least one mutable field is provided
-  if (Object.keys(updateFields).length === 0) {
-    throw new UserInputError(
-      'At least one field to update must be provided.',
-    );
-  }
+  const { actionScreen, externalId, rank } = data;
 
   // Find the SectionItem and its parent Section for access control
   const existingItem = await context.db.sectionItem.findUnique({
@@ -123,7 +112,7 @@ export async function updateSectionItem(
 
   const sectionItem = await dbUpdateSectionItem(context.db, {
     externalId,
-    ...updateFields,
+    rank,
   });
 
   const sectionItemForEvents: SectionItemPayload = {

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.integration.ts
@@ -1,0 +1,211 @@
+import { print } from 'graphql';
+import request from 'supertest';
+
+import { ApolloServer } from '@apollo/server';
+import { PrismaClient, Section } from '.prisma/client';
+
+import {
+  ActivitySource,
+  MozillaAccessGroup,
+} from 'content-common';
+
+import { client } from '../../../../database/client';
+import { ApprovedItem } from '../../../../database/types';
+
+import {
+  clearDb,
+  createSectionHelper,
+  createApprovedItemHelper,
+  createSectionItemHelper,
+} from '../../../../test/helpers';
+import { CREATE_SECTION_ITEM, UPDATE_SECTION_ITEM } from '../sample-mutations.gql';
+import { startServer } from '../../../../express';
+import { IAdminContext } from '../../../context';
+import { curatedCorpusEventEmitter as eventEmitter } from '../../../../events/init';
+import { SectionItemEventType } from '../../../../events/types';
+
+describe('mutations: SectionItem (updateSectionItem)', () => {
+  let app: Express.Application;
+  let db: PrismaClient;
+  let graphQLUrl: string;
+  let server: ApolloServer<IAdminContext>;
+  let section: Section;
+  let approvedItem: ApprovedItem;
+
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${MozillaAccessGroup.SCHEDULED_SURFACE_CURATOR_FULL}`,
+  };
+
+  beforeAll(async () => {
+    ({ app, adminServer: server, adminUrl: graphQLUrl } = await startServer(0));
+    db = client();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+    await clearDb(db);
+    await db.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
+
+    section = await createSectionHelper(db, {
+      createSource: ActivitySource.ML,
+    });
+
+    approvedItem = await createApprovedItemHelper(db, {
+      title: 'An Article About Testing',
+    });
+  });
+
+  afterEach(async () => {
+    await clearDb(db);
+  });
+
+  it('should update the rank of a SectionItem', async () => {
+    // Set up event tracking
+    const eventTracker = jest.fn();
+    eventEmitter.on(SectionItemEventType.UPDATE_SECTION_ITEM, eventTracker);
+
+    // First create a SectionItem with rank 1
+    const createResult = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(CREATE_SECTION_ITEM),
+        variables: {
+          data: {
+            sectionExternalId: section.externalId,
+            approvedItemExternalId: approvedItem.externalId,
+            rank: 1,
+          },
+        },
+      });
+
+    const sectionItemExternalId =
+      createResult.body.data?.createSectionItem.externalId;
+
+    // Now update the rank to 5
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_SECTION_ITEM),
+        variables: {
+          data: {
+            externalId: sectionItemExternalId,
+            rank: 5,
+          },
+        },
+      });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body.data).not.toBeNull();
+    expect(result.body.data?.updateSectionItem.rank).toEqual(5);
+    expect(result.body.data?.updateSectionItem.externalId).toEqual(
+      sectionItemExternalId,
+    );
+    // the associated approvedItem should still be there
+    expect(
+      result.body.data?.updateSectionItem.approvedItem.externalId,
+    ).toEqual(approvedItem.externalId);
+
+    // Check that the UPDATE_SECTION_ITEM event was fired
+    expect(eventTracker).toHaveBeenCalledTimes(1);
+    const eventData = await eventTracker.mock.calls[0][0];
+    expect(eventData.eventType).toEqual(
+      SectionItemEventType.UPDATE_SECTION_ITEM,
+    );
+    expect(eventData.sectionItem.externalId).toEqual(sectionItemExternalId);
+
+    // Clean up event listener
+    eventEmitter.removeAllListeners(SectionItemEventType.UPDATE_SECTION_ITEM);
+  });
+
+  it('should fail if the SectionItem does not exist', async () => {
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_SECTION_ITEM),
+        variables: {
+          data: {
+            externalId: 'nonexistent-uuid',
+            rank: 5,
+          },
+        },
+      });
+
+    expect(result.body.errors).not.toBeUndefined();
+    expect(result.body.errors?.[0].extensions?.code).toEqual('NOT_FOUND');
+    expect(result.body.errors?.[0].message).toContain(
+      'Cannot update a section item: Section item with id "nonexistent-uuid" does not exist.',
+    );
+  });
+
+  it('should fail if no mutable fields are provided', async () => {
+    // Create a SectionItem first
+    const createResult = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(CREATE_SECTION_ITEM),
+        variables: {
+          data: {
+            sectionExternalId: section.externalId,
+            approvedItemExternalId: approvedItem.externalId,
+            rank: 1,
+          },
+        },
+      });
+
+    const sectionItemExternalId =
+      createResult.body.data?.createSectionItem.externalId;
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_SECTION_ITEM),
+        variables: {
+          data: {
+            externalId: sectionItemExternalId,
+          },
+        },
+      });
+
+    expect(result.body.errors).not.toBeUndefined();
+    expect(result.body.errors?.[0].message).toContain(
+      'At least one field to update must be provided.',
+    );
+  });
+
+  it('should not update an inactive SectionItem', async () => {
+    // Directly create an inactive SectionItem in the DB
+    const sectionItem = await createSectionItemHelper(db, {
+      approvedItemId: approvedItem.id,
+      sectionId: section.id,
+      rank: 1,
+      active: false,
+    });
+
+    const result = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_SECTION_ITEM),
+        variables: {
+          data: {
+            externalId: sectionItem.externalId,
+            rank: 5,
+          },
+        },
+      });
+
+    expect(result.body.errors).not.toBeUndefined();
+    expect(result.body.errors?.[0].extensions?.code).toEqual('NOT_FOUND');
+  });
+});

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.integration.ts
@@ -146,43 +146,6 @@ describe('mutations: SectionItem (updateSectionItem)', () => {
     );
   });
 
-  it('should fail if no mutable fields are provided', async () => {
-    // Create a SectionItem first
-    const createResult = await request(app)
-      .post(graphQLUrl)
-      .set(headers)
-      .send({
-        query: print(CREATE_SECTION_ITEM),
-        variables: {
-          data: {
-            sectionExternalId: section.externalId,
-            approvedItemExternalId: approvedItem.externalId,
-            rank: 1,
-          },
-        },
-      });
-
-    const sectionItemExternalId =
-      createResult.body.data?.createSectionItem.externalId;
-
-    const result = await request(app)
-      .post(graphQLUrl)
-      .set(headers)
-      .send({
-        query: print(UPDATE_SECTION_ITEM),
-        variables: {
-          data: {
-            externalId: sectionItemExternalId,
-          },
-        },
-      });
-
-    expect(result.body.errors).not.toBeUndefined();
-    expect(result.body.errors?.[0].message).toContain(
-      'At least one field to update must be provided.',
-    );
-  });
-
   it('should not update an inactive SectionItem', async () => {
     // Directly create an inactive SectionItem in the DB
     const sectionItem = await createSectionItemHelper(db, {

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.spec.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.spec.ts
@@ -99,14 +99,6 @@ describe('updateSectionItem resolver', () => {
     );
   });
 
-  it('should throw UserInputError if no mutable fields are provided', async () => {
-    const data = { externalId: 'section-item-uuid' };
-
-    await expect(
-      updateSectionItem(null, { data }, mockContext),
-    ).rejects.toThrow('At least one field to update must be provided.');
-  });
-
   it('should throw NotFoundError if section item does not exist', async () => {
     (mockContext.db as any).sectionItem.findUnique.mockResolvedValueOnce(null);
 

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.spec.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/updateSectionItem.spec.ts
@@ -1,0 +1,133 @@
+import { updateSectionItem } from '.';
+import * as dbMutations from '../../../../database/mutations/SectionItem';
+import { IAdminContext } from '../../../context';
+import { SectionItemEventType } from '../../../../events/types';
+
+describe('updateSectionItem resolver', () => {
+  let dbUpdateSpy: jest.SpyInstance;
+
+  const mockSectionItem = {
+    id: 1,
+    externalId: 'section-item-uuid',
+    sectionId: 10,
+    approvedItemId: 20,
+    rank: 5,
+    active: true,
+    deactivateReasons: null,
+    deactivateSource: null,
+    deactivatedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    approvedItem: { externalId: 'approved-item-uuid', url: 'https://example.com' },
+    section: {
+      id: 10,
+      externalId: 'section-uuid',
+      scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+    },
+  };
+
+  const mockEmitSectionItemEvent = jest.fn();
+
+  const mockContext = {
+    authenticatedUser: {
+      canWriteToSurface: jest.fn().mockReturnValue(true),
+      username: 'test.user@test.com',
+    },
+    db: {
+      sectionItem: {
+        findUnique: jest.fn().mockResolvedValue({
+          ...mockSectionItem,
+          section: {
+            scheduledSurfaceGuid: 'NEW_TAB_EN_US',
+          },
+        }),
+      },
+    } as any,
+    emitSectionItemEvent: mockEmitSectionItemEvent,
+  } as unknown as IAdminContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    dbUpdateSpy = jest
+      .spyOn(dbMutations, 'updateSectionItem')
+      .mockResolvedValue(mockSectionItem as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should update rank on a SectionItem', async () => {
+    const data = { externalId: 'section-item-uuid', rank: 3 };
+
+    const result = await updateSectionItem(null, { data }, mockContext);
+
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(1);
+    expect(dbUpdateSpy).toHaveBeenCalledWith(mockContext.db, {
+      externalId: 'section-item-uuid',
+      rank: 3,
+    });
+    expect(result).toEqual(mockSectionItem);
+  });
+
+  it('should update rank to 0 (falsy value)', async () => {
+    const data = { externalId: 'section-item-uuid', rank: 0 };
+
+    await updateSectionItem(null, { data }, mockContext);
+
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(1);
+    expect(dbUpdateSpy).toHaveBeenCalledWith(mockContext.db, {
+      externalId: 'section-item-uuid',
+      rank: 0,
+    });
+  });
+
+  it('should emit UPDATE_SECTION_ITEM event', async () => {
+    const data = { externalId: 'section-item-uuid', rank: 3 };
+
+    await updateSectionItem(null, { data }, mockContext);
+
+    expect(mockEmitSectionItemEvent).toHaveBeenCalledTimes(1);
+    expect(mockEmitSectionItemEvent).toHaveBeenCalledWith(
+      SectionItemEventType.UPDATE_SECTION_ITEM,
+      expect.objectContaining({
+        sectionItem: expect.objectContaining({
+          externalId: 'section-item-uuid',
+        }),
+      }),
+    );
+  });
+
+  it('should throw UserInputError if no mutable fields are provided', async () => {
+    const data = { externalId: 'section-item-uuid' };
+
+    await expect(
+      updateSectionItem(null, { data }, mockContext),
+    ).rejects.toThrow('At least one field to update must be provided.');
+  });
+
+  it('should throw NotFoundError if section item does not exist', async () => {
+    (mockContext.db as any).sectionItem.findUnique.mockResolvedValueOnce(null);
+
+    const data = { externalId: 'nonexistent-uuid', rank: 3 };
+
+    await expect(
+      updateSectionItem(null, { data }, mockContext),
+    ).rejects.toThrow('does not exist');
+
+    expect(dbUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should throw AuthenticationError if user lacks surface access', async () => {
+    (mockContext.authenticatedUser.canWriteToSurface as jest.Mock).mockReturnValueOnce(false);
+
+    const data = { externalId: 'section-item-uuid', rank: 3 };
+
+    await expect(
+      updateSectionItem(null, { data }, mockContext),
+    ).rejects.toThrow('You do not have access to perform this action.');
+
+    expect(dbUpdateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -119,6 +119,15 @@ export const CREATE_SECTION_ITEM = gql`
   ${AdminSectionItemData}
 `;
 
+export const UPDATE_SECTION_ITEM = gql`
+  mutation updateSectionItem($data: UpdateSectionItemInput!) {
+    updateSectionItem(data: $data) {
+      ...AdminSectionItemData
+    }
+  }
+  ${AdminSectionItemData}
+`;
+
 export const REMOVE_SECTION_ITEM = gql`
   mutation removeSectionItem($data: RemoveSectionItemInput!) {
     removeSectionItem(data: $data) {

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -73,7 +73,7 @@ export default {
     sectionEvents: SectionEventType,
     sectionItemEvents: SectionItemEventType,
     schemas: {
-      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-21',
+      objectUpdate: 'iglu:com.pocket/object_update/jsonschema/1-0-22',
       reviewedCorpusItem:
         'iglu:com.pocket/reviewed_corpus_item/jsonschema/1-0-11',
       scheduledCorpusItem:

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from '.prisma/client';
 
 import {
   CreateSectionItemInput,
+  UpdateSectionItemInput,
   RemoveSectionItemInput,
   SectionItem,
 } from '../types';
@@ -78,6 +79,37 @@ export async function createSectionItem(
     },
   });
 }
+/**
+ * Updates a SectionItem's mutable fields (e.g. rank).
+ *
+ * @param db
+ * @param data
+ */
+export async function updateSectionItem(
+  db: PrismaClient,
+  data: UpdateSectionItemInput,
+): Promise<SectionItem> {
+  const { externalId, ...updateFields } = data;
+
+  return await db.sectionItem.update({
+    where: {
+      externalId,
+      active: true,
+    },
+    data: updateFields,
+    include: {
+      approvedItem: {
+        include: {
+          authors: {
+            orderBy: [{ sortOrder: 'asc' }],
+          },
+        },
+      },
+      section: true,
+    },
+  });
+}
+
 /**
  * This mutation removes a SectionItem from a Section.
  * The SectionItem is marked as in-active, `deactivatedBy` it set to MANUAL,

--- a/servers/curated-corpus-api/src/database/mutations/index.ts
+++ b/servers/curated-corpus-api/src/database/mutations/index.ts
@@ -11,5 +11,5 @@ export {
 } from './ScheduledItem';
 export { createScheduleReview } from './ScheduleReview';
 export { createSection, disableEnableSection, updateSection, createCustomSection, deleteCustomSection, updateCustomSection } from './Section';
-export { createSectionItem, removeSectionItem } from './SectionItem';
+export { createSectionItem, updateSectionItem, removeSectionItem } from './SectionItem';
 export { createOrUpdatePublisherDomain } from './PublisherDomain';

--- a/servers/curated-corpus-api/src/database/queries/Section.ts
+++ b/servers/curated-corpus-api/src/database/queries/Section.ts
@@ -53,6 +53,7 @@ export async function getSectionsWithSectionItems(
         where: {
           active: true,
         },
+        orderBy: { rank: 'asc' },
         include: {
           approvedItem: {
             include: {

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -131,7 +131,7 @@ export type CreateSectionItemInput = {
 
 export type UpdateSectionItemInput = {
   externalId: string;
-  rank?: number | null;
+  rank: number;
 };
 
 export type RemoveSectionItemInput = {

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -129,6 +129,11 @@ export type CreateSectionItemInput = {
   rank?: number;
 };
 
+export type UpdateSectionItemInput = {
+  externalId: string;
+  rank?: number | null;
+};
+
 export type RemoveSectionItemInput = {
   externalId: string;
   deactivateReasons: SectionItemRemovalReason[];

--- a/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
@@ -117,6 +117,7 @@ describe('SectionItemSnowplowHandler', () => {
 
   new SectionItemSnowplowHandler(emitter, tracker, [
     SectionItemEventType.ADD_SECTION_ITEM,
+    SectionItemEventType.UPDATE_SECTION_ITEM,
     SectionItemEventType.REMOVE_SECTION_ITEM,
   ]);
 
@@ -130,25 +131,31 @@ describe('SectionItemSnowplowHandler', () => {
       eventType: SectionItemEventType.ADD_SECTION_ITEM,
     });
 
+    emitter.emit(SectionItemEventType.UPDATE_SECTION_ITEM, {
+      ...sectionItemEventData,
+      eventType: SectionItemEventType.UPDATE_SECTION_ITEM,
+    });
+
     emitter.emit(SectionItemEventType.REMOVE_SECTION_ITEM, {
       ...sectionItemEventData,
       eventType: SectionItemEventType.REMOVE_SECTION_ITEM,
     });
 
     // make sure we only have good events
-    const allEvents = await waitForSnowplowEvents(2);
-    expect(allEvents.total).toEqual(2);
-    expect(allEvents.good).toEqual(2);
+    const allEvents = await waitForSnowplowEvents(3);
+    expect(allEvents.total).toEqual(3);
+    expect(allEvents.good).toEqual(3);
     expect(allEvents.bad).toEqual(0);
 
     const goodEvents = await getGoodSnowplowEvents();
 
     assertValidSnowplowSectionItemEvents(goodEvents[0].rawEvent.parameters.cx);
     assertValidSnowplowSectionItemEvents(goodEvents[1].rawEvent.parameters.cx);
+    assertValidSnowplowSectionItemEvents(goodEvents[2].rawEvent.parameters.cx);
 
     assertValidSnowplowObjectUpdateEvents(
       goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
-      ['section_item_added', 'section_item_removed'],
+      ['section_item_added', 'section_item_updated', 'section_item_removed'],
       'section_item',
     );
   });

--- a/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
@@ -117,6 +117,7 @@ describe('SectionItemSnowplowHandler', () => {
 
   new SectionItemSnowplowHandler(emitter, tracker, [
     SectionItemEventType.ADD_SECTION_ITEM,
+    SectionItemEventType.UPDATE_SECTION_ITEM,
     SectionItemEventType.REMOVE_SECTION_ITEM,
   ]);
 
@@ -149,6 +150,47 @@ describe('SectionItemSnowplowHandler', () => {
     assertValidSnowplowObjectUpdateEvents(
       goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
       ['section_item_added', 'section_item_removed'],
+      'section_item',
+    );
+  });
+
+  it('should send a good event to Snowplow on section item update with rank', async () => {
+    const updatedSectionItem: SectionItemPayload = {
+      sectionItem: {
+        ...mockSectionItem,
+        rank: 5,
+      },
+    };
+
+    emitter.emit(SectionItemEventType.UPDATE_SECTION_ITEM, {
+      ...updatedSectionItem,
+      eventType: SectionItemEventType.UPDATE_SECTION_ITEM,
+    });
+
+    const allEvents = await waitForSnowplowEvents();
+    expect(allEvents.total).toEqual(1);
+    expect(allEvents.good).toEqual(1);
+    expect(allEvents.bad).toEqual(0);
+
+    const goodEvents = await getGoodSnowplowEvents();
+
+    const eventContext = parseSnowplowData(
+      goodEvents[0].rawEvent.parameters.cx,
+    );
+
+    expect(eventContext.data).toMatchObject([
+      {
+        schema: config.snowplow.schemas.sectionItem,
+        data: {
+          ...sectionItemEventContextData,
+          rank: 5,
+        },
+      },
+    ]);
+
+    assertValidSnowplowObjectUpdateEvents(
+      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
+      ['section_item_updated'],
       'section_item',
     );
   });

--- a/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/SectionItemSnowplowHandler.integration.ts
@@ -117,7 +117,6 @@ describe('SectionItemSnowplowHandler', () => {
 
   new SectionItemSnowplowHandler(emitter, tracker, [
     SectionItemEventType.ADD_SECTION_ITEM,
-    SectionItemEventType.UPDATE_SECTION_ITEM,
     SectionItemEventType.REMOVE_SECTION_ITEM,
   ]);
 
@@ -150,47 +149,6 @@ describe('SectionItemSnowplowHandler', () => {
     assertValidSnowplowObjectUpdateEvents(
       goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
       ['section_item_added', 'section_item_removed'],
-      'section_item',
-    );
-  });
-
-  it('should send a good event to Snowplow on section item update with rank', async () => {
-    const updatedSectionItem: SectionItemPayload = {
-      sectionItem: {
-        ...mockSectionItem,
-        rank: 5,
-      },
-    };
-
-    emitter.emit(SectionItemEventType.UPDATE_SECTION_ITEM, {
-      ...updatedSectionItem,
-      eventType: SectionItemEventType.UPDATE_SECTION_ITEM,
-    });
-
-    const allEvents = await waitForSnowplowEvents();
-    expect(allEvents.total).toEqual(1);
-    expect(allEvents.good).toEqual(1);
-    expect(allEvents.bad).toEqual(0);
-
-    const goodEvents = await getGoodSnowplowEvents();
-
-    const eventContext = parseSnowplowData(
-      goodEvents[0].rawEvent.parameters.cx,
-    );
-
-    expect(eventContext.data).toMatchObject([
-      {
-        schema: config.snowplow.schemas.sectionItem,
-        data: {
-          ...sectionItemEventContextData,
-          rank: 5,
-        },
-      },
-    ]);
-
-    assertValidSnowplowObjectUpdateEvents(
-      goodEvents.map((goodEvent) => goodEvent.rawEvent.parameters.ue_px),
-      ['section_item_updated'],
       'section_item',
     );
   });

--- a/servers/curated-corpus-api/src/events/snowplow/schema.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/schema.ts
@@ -32,6 +32,7 @@ export type CuratedCorpusItemUpdate = {
     | 'section_updated' // Section is updated
     | 'section_removed' // Section is removed
     | 'section_item_added' // SectionItem is added
+    | 'section_item_updated' // SectionItem is updated
     | 'section_item_removed'; // SectionItem is removed
   object: 'reviewed_corpus_item' | 'scheduled_corpus_item' | 'section' | 'section_item';
 };

--- a/servers/curated-corpus-api/src/events/snowplow/schema.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/schema.ts
@@ -32,7 +32,6 @@ export type CuratedCorpusItemUpdate = {
     | 'section_updated' // Section is updated
     | 'section_removed' // Section is removed
     | 'section_item_added' // SectionItem is added
-    | 'section_item_updated' // SectionItem is updated
     | 'section_item_removed'; // SectionItem is removed
   object: 'reviewed_corpus_item' | 'scheduled_corpus_item' | 'section' | 'section_item';
 };

--- a/servers/curated-corpus-api/src/events/snowplow/types.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/types.ts
@@ -17,6 +17,7 @@ export type SnowplowEventType =
   | 'section_updated'
   | 'section_removed'
   | 'section_item_added'
+  | 'section_item_updated'
   | 'section_item_removed';
 
 export const ReviewedItemSnowplowEventMap: Record<
@@ -52,5 +53,6 @@ export const SectionItemSnowplowEventMap: Record<
   SnowplowEventType
 > = {
   ADD_SECTION_ITEM: 'section_item_added',
+  UPDATE_SECTION_ITEM: 'section_item_updated',
   REMOVE_SECTION_ITEM: 'section_item_removed',
 };

--- a/servers/curated-corpus-api/src/events/snowplow/types.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/types.ts
@@ -17,7 +17,6 @@ export type SnowplowEventType =
   | 'section_updated'
   | 'section_removed'
   | 'section_item_added'
-  | 'section_item_updated'
   | 'section_item_removed';
 
 export const ReviewedItemSnowplowEventMap: Record<
@@ -49,10 +48,9 @@ export const SectionSnowplowEventMap: Record<
 };
 
 export const SectionItemSnowplowEventMap: Record<
-  SectionItemEventTypeString,
+  Exclude<SectionItemEventTypeString, 'UPDATE_SECTION_ITEM'>,
   SnowplowEventType
 > = {
   ADD_SECTION_ITEM: 'section_item_added',
-  UPDATE_SECTION_ITEM: 'section_item_updated',
   REMOVE_SECTION_ITEM: 'section_item_removed',
 };

--- a/servers/curated-corpus-api/src/events/snowplow/types.ts
+++ b/servers/curated-corpus-api/src/events/snowplow/types.ts
@@ -17,6 +17,7 @@ export type SnowplowEventType =
   | 'section_updated'
   | 'section_removed'
   | 'section_item_added'
+  | 'section_item_updated'
   | 'section_item_removed';
 
 export const ReviewedItemSnowplowEventMap: Record<
@@ -48,9 +49,10 @@ export const SectionSnowplowEventMap: Record<
 };
 
 export const SectionItemSnowplowEventMap: Record<
-  Exclude<SectionItemEventTypeString, 'UPDATE_SECTION_ITEM'>,
+  SectionItemEventTypeString,
   SnowplowEventType
 > = {
   ADD_SECTION_ITEM: 'section_item_added',
+  UPDATE_SECTION_ITEM: 'section_item_updated',
   REMOVE_SECTION_ITEM: 'section_item_removed',
 };

--- a/servers/curated-corpus-api/src/events/types.ts
+++ b/servers/curated-corpus-api/src/events/types.ts
@@ -24,6 +24,7 @@ export enum SectionEventType {
 
 export enum SectionItemEventType {
   ADD_SECTION_ITEM = 'ADD_SECTION_ITEM',
+  UPDATE_SECTION_ITEM = 'UPDATE_SECTION_ITEM',
   REMOVE_SECTION_ITEM = 'REMOVE_SECTION_ITEM',
 }
 


### PR DESCRIPTION
## Goal

Make rank mutable on section items so ML can control the display order of items within sections (e.g., the 3-pack in Daily Briefing). This is a prerequisite for Daily Briefing Phase 2.

Previously, the section-manager Lambda skipped any candidate whose URL already existed in a section's active items. If ML sent a new batch where an existing item's rank changed, the Lambda ignored it. This PR adds an `updateSectionItem` mutation to the Corpus API and updates the Lambda to detect rank mismatches and call it.

## Changes

### Corpus API (`curated-corpus-api`)
- Add `UpdateSectionItemInput` GraphQL type with required `externalId` and `rank` (`Int!`)
- Add `updateSectionItem` mutation, resolver, and DB mutation
- Add `UPDATE_SECTION_ITEM` event type with Snowplow `section_item_updated` trigger mapping
- Bump `object_update` Snowplow schema from `1-0-21` to `1-0-22` (adds `section_item_updated` trigger)
- Order section items by rank (asc) in `getSectionsWithSectionItems` query

### Section Manager Lambda
- Add `updateSectionItem` GraphQL call
- Add `rank` to `ActiveSectionItem` type and `createOrUpdateSection` query response
- Detect rank mismatches on existing items and call `updateSectionItem`
- Use returned `externalId` from `createSectionItem` in `activeItemsByUrl` map
- Count rank-match no-ops as successful in log output

### Shared (`content-common`)
- Add `UpdateSectionItemApiInput` type with required `rank`

## References

- [Tech spec: Daily Briefing v2](https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/1780244486)
- [HNT-1359](https://mozilla-hub.atlassian.net/browse/HNT-1359)

## QA

### Setup
1. Start services: `docker compose up --wait`
2. Build: `pnpm build`
3. Reset DB: `cd servers/curated-corpus-api && npx prisma migrate reset --skip-seed --force`
4. Start server: `pnpm dev --filter=curated-corpus-api`

### Test 1: Create a section with items at known ranks

```bash
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:CreateOrUpdateSectionInput!){createOrUpdateSection(data:$data){externalId sectionItems{externalId rank}}}","variables":{"data":{"externalId":"test-section","title":"Test Section","scheduledSurfaceGuid":"NEW_TAB_EN_US","createSource":"ML","active":true}}}'
```

- [x] Section created with `externalId: "test-section"` and empty `sectionItems`

```json
{"data":{"createOrUpdateSection":{"externalId":"test-section","sectionItems":[]}}}
```

Create approved items directly in MySQL (the API requires S3 for image upload):

```sql
docker exec content-monorepo-mysql-1 mysql -u root curation_corpus -e "
INSERT INTO ApprovedItem (externalId, prospectId, url, domainName, title, excerpt, status, language, publisher, imageUrl, topic, source, isCollection, isSyndicated, isTimeSensitive, createdBy, createdAt, updatedAt) VALUES
('approved-item-1', 'p1', 'https://example.com/one', 'example.com', 'Article One', 'test', 'RECOMMENDATION', 'EN', 'Example', 'https://example.com/img.jpg', 'TECHNOLOGY', 'MANUAL', 0, 0, 0, 'test@test.com', NOW(), NOW()),
('approved-item-2', 'p2', 'https://example.com/two', 'example.com', 'Article Two', 'test', 'RECOMMENDATION', 'EN', 'Example', 'https://example.com/img.jpg', 'SCIENCE', 'MANUAL', 0, 0, 0, 'test@test.com', NOW(), NOW());"
```

```bash
# Create section item with rank 5
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:CreateSectionItemInput!){createSectionItem(data:$data){externalId rank approvedItem{url}}}","variables":{"data":{"sectionExternalId":"test-section","approvedItemExternalId":"approved-item-1","rank":5}}}'
```

- [x] Section item created with `rank: 5`

```json
{"data":{"createSectionItem":{"externalId":"c043...","rank":5,"approvedItem":{"url":"https://example.com/article-one"}}}}
```

```bash
# Create section item with rank 2
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:CreateSectionItemInput!){createSectionItem(data:$data){externalId rank approvedItem{url}}}","variables":{"data":{"sectionExternalId":"test-section","approvedItemExternalId":"approved-item-2","rank":2}}}'
```

- [x] Section item created with `rank: 2`

```json
{"data":{"createSectionItem":{"externalId":"4895...","rank":2,"approvedItem":{"url":"https://example.com/article-two"}}}}
```

### Test 2: Update rank via updateSectionItem mutation

```bash
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:UpdateSectionItemInput!){updateSectionItem(data:$data){externalId rank approvedItem{url}}}","variables":{"data":{"externalId":"SECTION_ITEM_ID","rank":0}}}'
```

- [x] Returns `rank: 0` (changed from 5)
- [x] `approvedItem.url` is unchanged

```json
{"data":{"updateSectionItem":{"externalId":"c043...","rank":0,"approvedItem":{"url":"https://example.com/article-one"}}}}
```

### Test 3: Update rank on non-existent item returns NOT_FOUND

```bash
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:UpdateSectionItemInput!){updateSectionItem(data:$data){externalId rank}}","variables":{"data":{"externalId":"nonexistent-id","rank":1}}}'
```

- [x] Returns error with `code: "NOT_FOUND"`
- [x] Message: `Cannot update a section item: Section item with id "nonexistent-id" does not exist.`

```json
{"errors":[{"message":"Error - Not Found: Cannot update a section item: Section item with id \"nonexistent-id\" does not exist.","extensions":{"code":"NOT_FOUND"}}],"data":null}
```

### Test 4: Rank is required (GraphQL validation)

```bash
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"mutation($data:UpdateSectionItemInput!){updateSectionItem(data:$data){externalId rank}}","variables":{"data":{"externalId":"some-id"}}}'
```

- [x] Returns GraphQL validation error: `Field "rank" of required type "Int!" was not provided.`

```json
{"errors":[{"message":"Variable \"$data\" got invalid value { externalId: \"some-id\" }; Field \"rank\" of required type \"Int!\" was not provided.","extensions":{"code":"BAD_USER_INPUT"}}]}
```

### Test 5: Section items returned ordered by rank

```bash
curl -s http://localhost:4025/admin \
  -H 'Content-Type: application/json' \
  -H 'name: Test User' -H 'username: test@test.com' \
  -H 'groups: mozilliansorg_pocket_scheduled_surface_curator_full' \
  -d '{"query":"query($scheduledSurfaceGuid:ID!){getSectionsWithSectionItems(scheduledSurfaceGuid:$scheduledSurfaceGuid){externalId sectionItems{externalId rank}}}","variables":{"scheduledSurfaceGuid":"NEW_TAB_EN_US"}}'
```

- [x] Section items ordered by rank ascending: rank 0 (article-one, updated) before rank 2 (article-two)

```json
{"data":{"getSectionsWithSectionItems":[{"externalId":"test-section","sectionItems":[{"externalId":"c043...","rank":0},{"externalId":"4895...","rank":2}]}]}}
```

### Test 6: Unit tests pass

```bash
pnpm test --filter=curated-corpus-api
pnpm test --filter=section-manager-lambda
```

- [x] curated-corpus-api: 11 suites, 307 tests passed
- [x] section-manager-lambda: 3 suites, 34 tests passed


[HNT-1359]: https://mozilla-hub.atlassian.net/browse/HNT-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ