### PR TITLE
fix(infra): increase dev Aurora Serverless v2 max capacity (HNT-2422)

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -19,7 +19,7 @@ const rds = {
   // the minimum down to 2 or lower, but of course upcoming product/system usage
   // and changes should be considered.
   minCapacity: isDev ? 1 : 4,
-  maxCapacity: isDev ? 1 : 128, // max allowed by AWS for Aurora Serverless V2
+  maxCapacity: isDev ? 2 : 128, // max allowed by AWS for Aurora Serverless V2
 };
 
 export const config = {


### PR DESCRIPTION
## Goal

Fix the curated-corpus-api dev environment outage caused by Aurora MySQL OOM.

- Increase dev Aurora Serverless v2 `maxCapacity` from 1 to 2 ACU

## Evidence

CloudWatch confirms the dev Aurora cluster has 0 bytes FreeableMemory since Apr 6. Application logs show every Prisma query failing with `ERROR HY000 (1041): Out of memory`, including the health check (`SELECT 'corpus API'`). This causes ECS to replace tasks every 3-4 min — 225 task starts on Apr 9 alone — making curated-corpus-api completely unreachable and producing 100% error rates on all GraphQL operations.

## Root Cause Analysis

The dev cluster is configured with `MinCapacity=1, MaxCapacity=1` ACU (prod: 4-128), so it cannot scale. At 1 ACU (~2 GB), Aurora's default buffer pool (75% of RAM ≈ 1.5 GB) plus internal overhead (~200-300 MB) leaves only 150-250 MB free even when healthy. InnoDB internal structures grow over time — swap grew ~28 MB/day after the last engine restart on Mar 25 — and eventually exhaust both physical memory and swap. Allowing the cluster to scale to 2 ACU doubles available memory, giving MySQL headroom for this growth.

<img width="430" height="321" alt="image" src="https://github.com/user-attachments/assets/a273066e-9484-4d66-bbd3-7f83902deb90" />

<img width="430" height="321" alt="image" src="https://github.com/user-attachments/assets/a1cbb206-caa1-4d34-9f96-a466884bcbf8" />


## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-2422