### PR TITLE
feat(logs): add access logging to corpus API ALB

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -8,6 +8,8 @@ const domain = isDev
   ? `${domainPrefix}.getpocket.dev`
   : `${domainPrefix}.readitlater.com`;
 
+const s3LogsBucket = isDev ? 'pocket-data-items-dev' : 'pocket-data-items';
+
 const snowplowEndpoint = isDev
   ? 'com-getpocket-prod1.mini.snplow.net'
   : 'd.getpocket.com';
@@ -31,6 +33,7 @@ export const config = {
   environment,
   domain,
   rds,
+  s3LogsBucket,
   tags: {
     service: name,
     environment,

--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -207,6 +207,9 @@ class CuratedCorpusAPI extends TerraformStack {
     } = dependencies;
 
     return new PocketALBApplication(this, 'application', {
+      accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
       internal: true,
       prefix: config.prefix,
       alb6CharacterPrefix: config.shortName,


### PR DESCRIPTION
## Goal

add ALB access logs to the corpus for security auditing.

deployed to dev and verified logs are being saved in S3.

## Implementation Decisions

- this follows patterns set for [client-api](https://github.com/Pocket/pocket-monorepo/blob/main/infrastructure/client-api/src/main.ts#L211) and [admin-api](https://github.com/Pocket/admin-api/blob/main/.aws/src/main.ts#L116). terraform modules will automatically create the proper folders in the bucket. (see [here](https://github.com/Pocket/pocket-monorepo/blob/main/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts#L122).)

## Deployment steps

- [x] Deployed to dev?

## References

JIRA ticket:

- [HNT-2543](https://mozilla-hub.atlassian.net/browse/HNT-2543)

[HNT-2543]: https://mozilla-hub.atlassian.net/browse/HNT-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ