### PR TITLE
chore: improve url validation for getUrlMetadata query resolver

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/index.spec.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/index.spec.ts
@@ -10,6 +10,8 @@ describe('lib', () => {
 
   describe('getUrlMetadata', () => {
     it('throws when the given URL is invalid', async () => {
+      // more comprehensive bad url tests are in lib.spec.ts
+      // this test just ensures the function throws on a bad url
       const badUrl = 'not url!';
 
       await expect(

--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/index.ts
@@ -4,7 +4,11 @@ import { UrlMetadata } from 'content-common';
 
 import config from '../../../../config';
 import { IAdminContext } from '../../../context';
-import { convertParserJsonToUrlMetadata, fetchUrlMetadata } from './lib';
+import {
+  convertParserJsonToUrlMetadata,
+  fetchUrlMetadata,
+  validateUrl,
+} from './lib';
 import { lookupPublisher } from '../../../../database/mutations/PublisherDomain';
 
 /**
@@ -21,10 +25,8 @@ export const getUrlMetadata = async (
   { url },
   context: IAdminContext,
 ): Promise<UrlMetadata> => {
-  try {
-    // validate url by throwing if url format is incorrect
-    new URL(url).toString();
-  } catch (error) {
+  // ensure url is a valid http/https URL
+  if (!validateUrl(url)) {
     throw new UserInputError(`${url} is not a valid url`);
   }
 

--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.spec.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.spec.ts
@@ -4,6 +4,7 @@ import {
   convertParserJsonToUrlMetadata,
   deriveAuthors,
   deriveDatePublished,
+  validateUrl,
 } from './lib';
 
 describe('lib', () => {
@@ -209,5 +210,74 @@ describe('lib', () => {
         undefined,
       );
     });
+  });
+
+  describe('validateUrl', () => {
+    const invalidUrls: string[] = [
+      'not a url',
+      'file:///etc/passwd',
+      'dict://localhost:6379/INFO',
+      'http://127.0.0.1/',
+      'http://127.0.0.1:443/',
+      'http://curated-corpus-api/',
+      'sftp://127.0.0.1/',
+      'ftp://example.com',
+      'gopher://127.0.0.1:6379/_INFO%0D%0A',
+      'http://[::1]:80/',
+      'http://2130706433/',
+      'http://[::ffff:127.0.0.1]/',
+      'http://0x7f000001/',
+      'http://2130706433:4000/',
+      'javascript:alert(1)',
+      'data:text/html,<h1>test</h1>',
+      'http://169.254.169.254/',
+      'http://0177.0.0.1/',
+      'https://example.com.',
+      'https://user:pass@example.com',
+      'https://user@example.com',
+      'http://localhost',
+      'http://192.168.1.1',
+      'http://10.0.0.1',
+      'http://0.0.0.0',
+      'http://',
+      'http://.example.com',
+      'http://example',
+      'http://172.16.0.1/',
+      'http://[fe80::1]/',
+      'http://[::ffff:172.16.0.1]/',
+    ];
+
+    const validUrls: string[] = [
+      'http://example.com',
+      'https://example.com/',
+      'http://example.com:8080',
+      'https://example.com',
+      'https://example.com:8080',
+      'https://example.com?param=test&test=yep',
+      'https://example.com?param=test&test=yep#anchor',
+      'https://sub.example.com',
+      'https://sub-dub.example.com',
+      'https://example.com/path/to/content',
+      'https://example.co.uk',
+      'https://example.museum',
+      // very rare case of no user/pass but with the format.
+      // just noting explicitly that this is okay, but in practice we should
+      // not get urls of this nature
+      'http://:@example.com/',
+    ];
+
+    test.each(invalidUrls)(
+      'returns false when the URL %p is invalid',
+      (invalidUrl: string) => {
+        expect(validateUrl(invalidUrl)).toBe(false);
+      },
+    );
+
+    test.each(validUrls)(
+      'returns true when the URL %p is valid',
+      (validUrl: string) => {
+        expect(validateUrl(validUrl)).toBe(true);
+      },
+    );
   });
 });

--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.ts
@@ -175,3 +175,51 @@ export const convertParserJsonToUrlMetadata = (
     url,
   };
 };
+
+/**
+ * ensures a given URL is valid for our use cases. we only want http/https urls
+ * that point to a valid domain/tld. IP addresses should not be allowed.
+ *
+ * built from https://github.com/The-Node-Forge/url-validator/blob/main/src/validateUrl.ts
+ * keeping code local for tweaks and reduce package dependencies for a straight
+ * forward function.
+ *
+ * @param url
+ * @returns boolean
+ */
+export const validateUrl = (url: string): boolean => {
+  try {
+    const parsedUrl = new URL(url);
+
+    // ensure valid protocols (http/https)
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return false;
+    }
+
+    // check for user:password in domain
+    if (parsedUrl.username || parsedUrl.password) {
+      return false;
+    }
+
+    // check for valid domain/TLD
+    // isIp is an extra careful check; tldts sets domain=null for IPs
+    const parsed = parse(parsedUrl.hostname);
+    if (!parsed.domain || parsed.isIp) {
+      return false;
+    }
+
+    // reject hostnames with a leading dot
+    if (parsedUrl.hostname.startsWith('.')) {
+      return false;
+    }
+
+    // reject hostnames with a trailing dot
+    if (parsedUrl.hostname.endsWith('.')) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Goal

perform tighter validation on URL value passed to `getUrlMetadata` query resolver.

## Implementation Decisions

- allow only http/https URLs with valid domains

## Deployment steps

- [x] Deployed to dev?

## References

JIRA ticket:

- [HNT-2547](https://mozilla-hub.atlassian.net/browse/HNT-2547)


[HNT-2547]: https://mozilla-hub.atlassian.net/browse/HNT-2547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ