### PR TITLE
Hnt 2572 enable connection logs for corpus alb

### DIFF
--- a/infrastructure/curated-corpus-api/package.json
+++ b/infrastructure/curated-corpus-api/package.json
@@ -15,7 +15,7 @@
     "format": "eslint --fix \"src/**/*.ts\""
   },
   "dependencies": {
-    "@pocket-tools/terraform-modules": "5.20.0",
+    "@pocket-tools/terraform-modules": "5.25.0",
     "@cdktf/provider-aws": "19.49.1",
     "@cdktf/provider-local": "10.1.1",
     "@cdktf/provider-null": "10.0.1",

--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -166,6 +166,7 @@ class CuratedCorpusAPI extends TerraformStack {
           maxCapacity: config.rds.maxCapacity,
         },
         createServerlessV2Instance: true,
+        enabledCloudwatchLogsExports: ['audit', 'error', 'general'],
       },
 
       tags: config.tags,

--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -207,7 +207,14 @@ class CuratedCorpusAPI extends TerraformStack {
     } = dependencies;
 
     return new PocketALBApplication(this, 'application', {
+      // the underlying terraform modules code will create a specific folder
+      // for access logs (/alb) and connection logs (/alb-connection) within
+      // the provided bucket.
+      // see https://github.com/Pocket/pocket-monorepo/blob/main/packages/terraform-modules/src/base/ApplicationLoadBalancer.ts#L143
       accessLogs: {
+        existingBucket: config.s3LogsBucket,
+      },
+      connectionLogs: {
         existingBucket: config.s3LogsBucket,
       },
       internal: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: 13.15.1
         version: 13.15.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
       '@pocket-tools/terraform-modules':
-        specifier: 5.20.0
-        version: 5.20.0(encoding@0.1.13)(ink@3.2.0(react@17.0.2))(react@17.0.2)
+        specifier: 5.25.0
+        version: 5.25.0(encoding@0.1.13)(ink@3.2.0(react@17.0.2))(react@17.0.2)
       cdktf:
         specifier: 0.20.11
         version: 0.20.11(constructs@10.4.2)
@@ -2986,6 +2986,9 @@ packages:
   '@pocket-tools/terraform-modules@5.20.0':
     resolution: {integrity: sha512-1xY35wuHUmiB/8KSJ2Oyn/0x1eooJsJhuf2mGM9ODnhHa5bzUlKaFPsvQyCH2Nc5MVG7BMsHIDeSiSuWjsFTqA==}
 
+  '@pocket-tools/terraform-modules@5.25.0':
+    resolution: {integrity: sha512-DhBSdmhqTd1tmTh4IFpqwVOP3+MjkjMj1axF6qVC4091Ycp0xKDdlcSTIJArlUJOt0MG0reTs4dGUoBkVORG2Q==}
+
   '@pocket-tools/tracing@1.12.0':
     resolution: {integrity: sha512-92jjl2Bb0wTPTAsSvs5gyufXjX8+9+vY919fvPCwd6omqbM552TTsFDW2rdVA7j55QowS8VVarJCXHc+/ocQ8w==}
 
@@ -3902,6 +3905,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.9.2':
     resolution: {integrity: sha512-tS+lqTU3N0kkthU+rYp0spAYq15DU8ld9kXkaKg9sbQqJNF+WPMuNHZQGCgdxrUOEO0j22RKMwRVhF1HTl+X8A==}
@@ -8072,8 +8076,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20260305:
-    resolution: {integrity: sha512-JCpaEoo18VAXaQRsvdMLhwExx3k8QoryqWFTJXIvl3zkyVr5Gybd9Ap8mLatOP1RGfiUSYA7cW/mISZGBoBrbw==}
+  typescript@6.0.0-dev.20260416:
+    resolution: {integrity: sha512-64CCow5rQc6+oBAPqLtvZ8f3iz4WVCLwMVkg6/kOfMQlGshVOMkBhCXn+MMP4SX4Xtnz48VpD98FkptirMEuEQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -11465,6 +11469,31 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@pocket-tools/terraform-modules@5.25.0(encoding@0.1.13)(ink@3.2.0(react@17.0.2))(react@17.0.2)':
+    dependencies:
+      '@cdktf/provider-archive': 10.3.0(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-aws': 19.49.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-local': 10.1.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-newrelic': 12.23.0(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-null': 10.0.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-pagerduty': 13.15.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      '@cdktf/provider-time': 10.2.1(cdktf@0.20.11(constructs@10.4.2))(constructs@10.4.2)
+      cdktf: 0.20.11(constructs@10.4.2)
+      cdktf-cli: 0.20.11(encoding@0.1.13)(ink@3.2.0(react@17.0.2))(react@17.0.2)
+      constructs: 10.4.2
+      lodash: 4.17.21
+      parse-domain: 5.0.0(encoding@0.1.13)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - encoding
+      - ink
+      - react
+      - supports-color
+      - utf-8-validate
+
   '@pocket-tools/tracing@1.12.0(@opentelemetry/instrumentation@0.56.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -13748,7 +13777,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20260305
+      typescript: 6.0.0-dev.20260416
 
   drange@1.1.1: {}
 
@@ -17709,7 +17738,7 @@ snapshots:
 
   typescript@5.6.2: {}
 
-  typescript@6.0.0-dev.20260305: {}
+  typescript@6.0.0-dev.20260416: {}
 
   typia@7.6.4(@samchon/openapi@2.5.3)(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
## Goal

enable connection logs for corpus ALB, and enable cloudwatch exports (audit, error, and general) for copus DB. adding this logging for better monitoring.

- enable corpus ALB connection logs
- export alert, error, and general corpus DB logs to cloudwatch

## Deployment steps

- [ ] Deployed to dev?

## References

JIRA ticket:

- [HNT-2572](https://mozilla-hub.atlassian.net/browse/HNT-2572)
- [HNT-2553](https://mozilla-hub.atlassian.net/browse/HNT-2553)


[HNT-2572]: https://mozilla-hub.atlassian.net/browse/HNT-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HNT-2553]: https://mozilla-hub.atlassian.net/browse/HNT-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ