### PR TITLE
fix(HNT-2665): add PL to CorpusLanguage enum

### DIFF
--- a/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/utils.spec.ts
@@ -290,7 +290,7 @@ describe('utils', function () {
       ).rejects.toThrow(
         new Error(
           `failed to map a4b5d99c-4c1b-4d35-bccf-6455c8df07b0 to CreateApprovedCorpusItemApiInput. ` +
-            `Reason: Error: Error on assert(): invalid type on $input.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT")`,
+            `Reason: Error: Error on assert(): invalid type on $input.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | "PL")`,
         ),
       );
     });

--- a/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
@@ -251,7 +251,7 @@ describe('validation', function () {
       expect(() => {
         validateCandidate(badScheduledCandidate);
       }).toThrow(
-        'Error on assert(): invalid type on $input.scheduled_corpus_item.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | null)',
+        'Error on assert(): invalid type on $input.scheduled_corpus_item.language, expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | "PL" | null)',
       );
     });
 
@@ -296,7 +296,7 @@ describe('validation', function () {
 
     it.each([
       ['authors', 'Array<string>'],
-      ['language', '"DE" | "EN" | "ES" | "FR" | "IT"'],
+      ['language', '"DE" | "EN" | "ES" | "FR" | "IT" | "PL"'],
     ])('should validate optional non-string properties', (field, type) => {
       const badScheduledCandidate = createScheduledCandidate() as any;
 

--- a/lambdas/section-manager-lambda/src/validators.spec.ts
+++ b/lambdas/section-manager-lambda/src/validators.spec.ts
@@ -213,7 +213,7 @@ describe('validation', function () {
 
     it.each([
       ['authors', 'Array<string>'],
-      ['language', '"DE" | "EN" | "ES" | "FR" | "IT"'],
+      ['language', '"DE" | "EN" | "ES" | "FR" | "IT" | "PL"'],
     ])('should validate optional non-string properties', (field, type) => {
       // null is a valid value from ML
       sqsData.candidates[0][field] = null;

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -16,6 +16,7 @@ export enum CorpusLanguage {
   ES = 'ES',
   FR = 'FR',
   IT = 'IT',
+  PL = 'PL',
 }
 
 export enum Topics {

--- a/servers/curated-corpus-api/schema-shared.graphql
+++ b/servers/curated-corpus-api/schema-shared.graphql
@@ -38,6 +38,8 @@ enum CorpusLanguage {
   FR
   "Spanish"
   ES
+  "Polish"
+  PL
 }
 
 """

--- a/servers/prospect-api/schema.graphql
+++ b/servers/prospect-api/schema.graphql
@@ -9,6 +9,8 @@ enum CorpusLanguage {
   FR
   "Spanish"
   ES
+  "Polish"
+  PL
 }
 
 """


### PR DESCRIPTION
## Problem

[HNT-2665](https://mozilla-hub.atlassian.net/browse/HNT-2665) The Polish New Tab market (`NEW_TAB_PL_PL`) shows up in the curation tool dropdown, but **no ML sections are visible** for it.

## Root cause

ML generates all 17 Polish sections and pushes them to the Section Manager Lambda, but **every message is rejected at input validation** because `PL` was never added to `CorpusLanguage`:

```
Invoke Error: Error on assert(): invalid type on $input.candidates[0].language,
expect to be ("DE" | "EN" | "ES" | "FR" | "IT" | null), value: "PL"
  at validateSqsData (/var/task/validators.js:176:12)
```

The validator throws on the first candidate, so the **entire SQS batch fails** and nothing is persisted. (`typia` compiles `CorpusLanguage` into the lambda validators, and it also backs the GraphQL enums the lambdas call into.)

### Evidence
- **CloudWatch** (`/aws/lambda/SectionManagerLambda-Prod-SQS-Function`, last 24h): **2,431** `value:"PL"` `Invoke Error`s — 100% of PL messages.
- **Curated corpus DB**: `SELECT … FROM Section WHERE scheduledSurfaceGuid = 'NEW_TAB_PL_PL'` → **0 rows**.
- The surface still appears in the dropdown because that comes from the `ScheduledSurfaces` registry, independent of `CorpusLanguage`.

# Deployment

`CorpusLanguage` is a federated input+output enum, so all subgraphs defining it must have `PL` before the supergraphs recompose. Subgraphs publish automatically on merge to `main`.

- [ ] **Delete the stale `user-list-search` subgraph** in Apollo. It still defines `CorpusLanguage` without `PL` and has no active deploy pipeline, so it would block `pocket-client-api` composition.
  Supersedes Pocket/pocket-monorepo#1109 — close it.
- [ ] **Merge this PR** → auto-publishes `curated-corpus`+PL to both supergraphs and `prospect-api`+PL to `pocket-admin-api`.
- [ ] **Verify**: lambda logs show `processSqsSectionData` succeeding for `NEW_TAB_PL_PL`, and `Section` rows appear for `scheduledSurfaceGuid='NEW_TAB_PL_PL'`.
- [ ] **Deploy** the curation tool language picker (Pocket/curation-admin-tools#1276).
- [ ] Delete other legacy Pocket subgraphs. [HNT-1542](https://mozilla-hub.atlassian.net/browse/HNT-1542)

> The pre-merge `rover subgraph check` stays red until these land (flag-day mutual dependency), so this PR likely needs an admin merge.

[HNT-2665]: https://mozilla-hub.atlassian.net/browse/HNT-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[HNT-1542]: https://mozilla-hub.atlassian.net/browse/HNT-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ