### PR TITLE
fix(corpus-api): prevent ApprovedItemAuthor wipe on update of non-existent item (HNT-2672)

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts
@@ -1,5 +1,6 @@
 import {
   AuthenticationError,
+  NotFoundError,
   UserInputError,
 } from '@pocket-tools/apollo-utils';
 import { ActionScreen, Topics } from 'content-common';
@@ -218,10 +219,20 @@ export async function updateApprovedItem(
     updatedItemData.externalId,
   );
 
+  // Guard against a non-existent item. Without this check, `existingItem` is
+  // null, `existingItem?.id` is `undefined`, and Prisma drops the undefined
+  // filter field — turning the deleteMany below into a delete-ALL that wipes
+  // the entire ApprovedItemAuthor table (HNT-2672).
+  if (!existingItem) {
+    throw new NotFoundError(
+      `Could not find an approved item with external id of "${updatedItemData.externalId}".`,
+    );
+  }
+
   // Remove the old author(s) from the DB records before we run the update function
   await context.db.approvedItemAuthor.deleteMany({
     where: {
-      approvedItemId: existingItem?.id,
+      approvedItemId: existingItem.id,
     },
   });
 

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/updateApprovedCorpusItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/updateApprovedCorpusItem.integration.ts
@@ -130,6 +130,62 @@ describe('mutations: ApprovedItem (updateApprovedCorpusItem)', () => {
     ).toEqual(data?.updateApprovedCorpusItem.externalId);
   });
 
+  // Regression guard for HNT-2672. Prevents all authors getting deleted, which happened on 2026-06-09.
+  it('should not delete any authors when updating a non-existent externalId', async () => {
+    // Create a SECOND approved item (in addition to `item` from beforeEach),
+    // also with authors. Both items' authors must survive the failed update.
+    const itemA = item;
+    const itemB = await createApprovedItemHelper(db, {
+      title: 'A second LEGO story',
+      status: CuratedStatus.RECOMMENDATION,
+      language: 'EN',
+    });
+
+    // Snapshot the total number of authors across the whole table before the
+    // update. The HNT-2672 bug wiped the entire ApprovedItemAuthor table.
+    const authorCountBefore = await db.approvedItemAuthor.count();
+    expect(authorCountBefore).toBeGreaterThan(0);
+
+    // Update using a random externalId that does not exist in the DB.
+    const badInput = {
+      ...input,
+      externalId: 'this-external-id-does-not-exist-12345',
+    };
+
+    const res = await request(app)
+      .post(graphQLUrl)
+      .set(headers)
+      .send({
+        query: print(UPDATE_APPROVED_ITEM),
+        variables: { data: badInput },
+      });
+
+    // The mutation must fail with a NotFound error...
+    expect(res.body.data).toBeNull();
+    expect(res.body.errors).not.toBeUndefined();
+    expect(res.body.errors?.[0].extensions?.code).toEqual('NOT_FOUND');
+    expect(res.body.errors?.[0].message).toContain(
+      `Could not find an approved item with external id of "${badInput.externalId}".`,
+    );
+
+    // ...and CRITICALLY, no authors may have been deleted.
+    const authorCountAfter = await db.approvedItemAuthor.count();
+    expect(authorCountAfter).toEqual(authorCountBefore);
+
+    // Re-fetch both items and confirm their authors are intact and unchanged.
+    const refetchedA = await db.approvedItem.findUnique({
+      where: { externalId: itemA.externalId },
+      include: { authors: { orderBy: [{ sortOrder: 'asc' }] } },
+    });
+    const refetchedB = await db.approvedItem.findUnique({
+      where: { externalId: itemB.externalId },
+      include: { authors: { orderBy: [{ sortOrder: 'asc' }] } },
+    });
+
+    expect(refetchedA?.authors).toEqual(itemA.authors);
+    expect(refetchedB?.authors).toEqual(itemB.authors);
+  });
+
   it('should succeed if optional data is not provided', async () => {
     // Set up event tracking
     const eventTracker = jest.fn();


### PR DESCRIPTION
## Summary

[HNT-2672](https://mozilla-hub.atlassian.net/browse/HNT-2672) On 2026-06-09 every author row in the `ApprovedItemAuthor` table was deleted in production. About 750,000 rows were lost. The bug had been present since January 2024.

### The fix

This is a forward fix. It prevents the bug from happening again but does not recover the authors that were already deleted. See Next steps for recovery.

If the item does not exist, throw `NotFoundError` before the delete runs. The delete can no longer run with an undefined filter, and the request fails with a `NOT_FOUND` error.

## Root cause

The `updateApprovedCorpusItem` resolver in `servers/curated-corpus-api/src/admin/resolvers/mutations/ApprovedItem/index.ts` looks up the item by `externalId` with `getApprovedItemByExternalId`. That function is a Prisma `findUnique`, so it returns `null` when no item matches.

```js
const existingItem = await getApprovedItemByExternalId(context.db, updatedItemData.externalId);
await context.db.approvedItemAuthor.deleteMany({ where: { approvedItemId: existingItem?.id } });
```

When the `externalId` does not exist, `existingItem` is `null`, so `existingItem?.id` is `undefined`. Prisma ignores an undefined filter field, so the `deleteMany` runs as `DELETE FROM ApprovedItemAuthor WHERE 1=1` and removes every author row in the table. In production the call came from the `HydrateSectionItemsFlow` job. It tried to update an item that an editor had just rejected and removed.

### Evidence

#### Destructive statement in Performance Insights

The exact statement was `DELETE FROM curation_corpus.ApprovedItemAuthor WHERE 1=1`. It ran as the application database user `pkt_curation_corpus` from an ECS task inside the VPC at about 14:08 UTC on 2026-06-09. This command prints it from Performance Insights.

```bash
aws --profile PocketSSORead-Prod --region us-east-1 pi describe-dimension-keys \
  --service-type RDS --identifier db-HLMYRWYIAQXYEORGUNMMIKPIPE \
  --start-time 2026-06-09T14:07:00Z --end-time 2026-06-09T14:10:00Z \
  --metric db.load.avg --group-by '{"Group":"db.sql","Limit":25}' \
  --query "Keys[?contains(Dimensions.\"db.sql.statement\", 'DELETE')].Dimensions.\"db.sql.statement\"" \
  --output text
```

#### Author table is far smaller than it should be

For items created in May 2026 the database now has authors for 0 of them. Snowplow recorded 80,450 of those items as created with an author. This MySQL query returns 0.

```sql
SELECT COUNT(DISTINCT a.approvedItemId) FROM ApprovedItemAuthor a JOIN ApprovedItem ai ON ai.id=a.approvedItemId WHERE ai.createdAt>='2026-05-01' AND ai.createdAt<'2026-06-01';
```

This BigQuery query returns 80,450.

```sql
SELECT COUNT(DISTINCT approved_corpus_item_external_id) FROM stg_reviewed_corpus_items_v1 WHERE object_update_trigger='reviewed_corpus_item_added' AND TRIM(authors)!='' AND happened_at>='2026-05-01' AND happened_at<'2026-06-01';
```

#### Author loss starts suddenly at 14:08 UTC on 2026-06-09

Items created before that time have no author unless an editor added one again. Items created after that time keep their author. This query shows the share with an author jump from about 2 percent up to about 96 percent.

```sql
SELECT ai.createdAt>='2026-06-09 14:08:00' AS after_1408, COUNT(*) items, SUM(a.approvedItemId IS NOT NULL) with_author FROM ApprovedItem ai LEFT JOIN (SELECT DISTINCT approvedItemId FROM ApprovedItemAuthor) a ON a.approvedItemId=ai.id WHERE ai.createdAt>='2026-06-09' GROUP BY after_1408;
```

```
+------------+-------+-------------+
| after_1408 | items | with_author |
+------------+-------+-------------+
|          0 |  1746 |          36 |
|          1 |  7472 |        7200 |
+------------+-------+-------------+
```

# Next steps

1. Decide how to backfill the deleted authors.
2. Guard the other destructive delete operations. This is started in [#393](https://github.com/Pocket/content-monorepo/pull/393).


[HNT-2672]: https://mozilla-hub.atlassian.net/browse/HNT-2672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

