### PR TITLE
refactor(corpus-api): guard destructive deleteMany/updateMany against undefined filters (HNT-2672 follow-up)

### DIFF
--- a/servers/curated-corpus-api/src/database/mutations/Section.ts
+++ b/servers/curated-corpus-api/src/database/mutations/Section.ts
@@ -2,6 +2,7 @@ import { PrismaClient, Prisma } from '.prisma/client';
 import { CreateCustomSectionInput, CreateSectionInput, DisableEnableSectionInput, UpdateCustomSectionInput, Section } from '../types';
 import { ActivitySource } from 'content-common';
 import { generateSectionSlug } from '../queries/Section';
+import { assertDefined } from '../../shared/utils';
 
 /**
  * This mutation creates a new Section.
@@ -216,6 +217,13 @@ export async function deleteCustomSection(
   sectionId:number,
   sectionExternalId: string
 ): Promise<Section> {
+  // Guard against the Prisma "undefined filter" footgun (HNT-2672): if
+  // `sectionId` were null/undefined, Prisma would drop it from the `where`
+  // below. The `active: true` literal would still bound this particular
+  // updateMany, but we assert defined-ness for clarity/safety so this never
+  // silently widens to "all active SectionItems". See src/shared/utils.ts.
+  assertDefined(sectionId, 'sectionId');
+
   const sectionItemUpdateData: Prisma.SectionItemUpdateManyMutationInput = {
     active: false,
     deactivateSource: ActivitySource.MANUAL,

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
@@ -254,5 +254,31 @@ describe('SectionItem', () => {
       // ...and it should be associated to approvedItem2
       expect(sectionItems[0].approvedItemId).toEqual(approvedItem2.id);
     });
+
+    it('should throw and delete nothing when approvedItemId is undefined', async () => {
+      // Guards against the Prisma "undefined filter" footgun (HNT-2672): an
+      // undefined filter value would otherwise wipe the entire SectionItem
+      // table. The guard must reject before any rows are touched.
+      const approvedItem = await createApprovedItemHelper(db, {
+        title: 'Fake Item!',
+      });
+      const section = await createSectionHelper(db, {});
+
+      await createSectionItemHelper(db, {
+        approvedItemId: approvedItem.id,
+        sectionId: section.id,
+        rank: 1,
+        active: true,
+      });
+
+      await expect(
+        deleteSectionItemsByApprovedItemId(db, undefined as any),
+      ).rejects.toThrow('"approvedItemId" must be defined');
+
+      // nothing should have been deleted
+      const remaining = await db.sectionItem.findMany();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].approvedItemId).toEqual(approvedItem.id);
+    });
   });
 });

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -9,6 +9,7 @@ import {
   SectionItem,
 } from '../types';
 import { ActivitySource } from 'content-common';
+import { assertDefined } from '../../shared/utils';
 
 /**
  * This mutation creates a SectionItem & adds it to a Section
@@ -161,6 +162,13 @@ export async function deleteSectionItemsByApprovedItemId(
   db: PrismaClient,
   approvedItemId: number,
 ): Promise<void> {
+  // Guard against the Prisma "undefined filter" footgun: if `approvedItemId`
+  // were null/undefined, Prisma would drop the `where` field and this
+  // deleteMany would wipe the ENTIRE SectionItem table (HNT-2672). The `where`
+  // here has no bounding literal, so this guard is the only thing scoping the
+  // delete. See assertDefined in src/shared/utils.ts.
+  assertDefined(approvedItemId, 'approvedItemId');
+
   // TODO: we may want to emit an alaytics event here, as this action destroys
   // corpus-level history on SectionItems
   await db.sectionItem.deleteMany({

--- a/servers/curated-corpus-api/src/shared/utils.spec.ts
+++ b/servers/curated-corpus-api/src/shared/utils.spec.ts
@@ -13,6 +13,7 @@ import {
   normalizeDomain,
   validateDomainName,
   validateHttpUrl,
+  assertDefined,
 } from './utils';
 import { ApprovedItem } from '../database/types';
 
@@ -493,6 +494,29 @@ describe('shared/utils', () => {
           '"com" is not a valid domain name.',
         );
       });
+    });
+  });
+
+  describe('assertDefined', () => {
+    it('returns the value when it is defined', () => {
+      expect(assertDefined(123, 'id')).toBe(123);
+      expect(assertDefined(0, 'id')).toBe(0);
+      expect(assertDefined('', 'name')).toBe('');
+      expect(assertDefined(false, 'flag')).toBe(false);
+      const obj = { a: 1 };
+      expect(assertDefined(obj, 'obj')).toBe(obj);
+    });
+
+    it('throws when the value is undefined', () => {
+      expect(() => assertDefined(undefined, 'approvedItemId')).toThrow(
+        'assertDefined: "approvedItemId" must be defined, but received undefined.',
+      );
+    });
+
+    it('throws when the value is null', () => {
+      expect(() => assertDefined(null, 'sectionId')).toThrow(
+        'assertDefined: "sectionId" must be defined, but received null.',
+      );
     });
   });
 });

--- a/servers/curated-corpus-api/src/shared/utils.ts
+++ b/servers/curated-corpus-api/src/shared/utils.ts
@@ -7,6 +7,53 @@ import { parse as parseDomain, getDomain } from 'tldts';
 import { DateTime } from 'luxon';
 
 /**
+ * DESTRUCTIVE PRISMA FOOTGUN — READ BEFORE WRITING deleteMany/updateMany
+ *
+ * Prisma silently DROPS `where` fields whose value is `undefined`. As a
+ * result, a query like:
+ *
+ *     db.someModel.deleteMany({ where: { fooId: undefined } })
+ *
+ * does NOT match "rows where fooId is undefined"; it compiles to
+ * `DELETE ... WHERE 1=1`, i.e. it wipes the ENTIRE table. The same is true
+ * for `updateMany`. This was the root cause of the HNT-2672 incident, where
+ * an `undefined` filter value turned a scoped delete into a delete-all.
+ *
+ * REQUIRED PATTERN for any destructive `deleteMany`/`updateMany`:
+ *   1. The `where` clause MUST contain at least one non-optional literal that
+ *      bounds the operation (e.g. `active: true`), OR
+ *   2. Every dynamic filter value MUST be validated as defined before the call
+ *      — use `assertDefined(value, 'name')` (below) at the top of the function.
+ *
+ * Do NOT build a destructive `where` from an optional-chained value such as
+ * `x?.id` without first running it through `assertDefined`.
+ */
+
+/**
+ * Asserts that a value is neither `null` nor `undefined`, returning it
+ * narrowed to its non-nullable type. Throws otherwise.
+ *
+ * Intended as a guard in front of destructive Prisma `deleteMany`/`updateMany`
+ * calls, where an `undefined` filter value silently widens the operation to
+ * the entire table (see the footgun note above and HNT-2672).
+ *
+ * @param value The value that must be defined.
+ * @param name A human-readable name for the value, used in the error message.
+ * @throws Error if `value` is `null` or `undefined`.
+ */
+export function assertDefined<T>(
+  value: T | null | undefined,
+  name: string,
+): T {
+  if (value === null || value === undefined) {
+    throw new Error(
+      `assertDefined: "${name}" must be defined, but received ${value}.`,
+    );
+  }
+  return value;
+}
+
+/**
  * Generate an integer Epoch time from a JavaScript Date object.
  *
  * @param date


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the Prisma "undefined filter → operate on all rows" footgun that caused the HNT-2672 prod incident.

Prisma silently **drops** `where` fields whose value is `undefined`. A scoped destructive query like:

```ts
db.someModel.deleteMany({ where: { fooId: undefined } })
```

does not match "rows where `fooId` is undefined" — it compiles to `DELETE ... WHERE 1=1` and wipes the **entire table**. The same applies to `updateMany`.

> The primary fix for the actual buggy resolver (`updateApprovedItem`) is being handled in a **separate PR**. This PR is purely defense-in-depth on the *other* destructive call sites plus a reusable guard, and intentionally does not touch that resolver or its test to avoid conflicts.

## Changes

**Reusable guard** (`src/shared/utils.ts`)
- Added `assertDefined<T>(value, name): T` — throws if the value is `null`/`undefined`, otherwise returns it narrowed to the non-nullable type.
- Added a prominent footgun doc-comment above it describing the failure mode and the required pattern for any destructive `deleteMany`/`updateMany`.

**Hardened call sites**
- `src/database/mutations/SectionItem.ts` — `deleteSectionItemsByApprovedItemId`: its `where: { approvedItemId }` has no bounding literal, so an `undefined` id would wipe the whole `SectionItem` table. Added `assertDefined(approvedItemId, 'approvedItemId')` before the `deleteMany`.
- `src/database/mutations/Section.ts` — `deleteCustomSection`: the `updateMany({ where: { sectionId, active: true } })` is lower-risk because the `active: true` literal bounds it, but added `assertDefined(sectionId, 'sectionId')` for clarity/safety.

**Tests**
- `src/shared/utils.spec.ts` — unit tests for `assertDefined` (returns defined values incl. falsy `0`/`''`/`false`; throws on `null` and `undefined`).
- `src/database/mutations/SectionItem.integration.ts` — integration test asserting `deleteSectionItemsByApprovedItemId(db, undefined)` throws and deletes nothing.

## Lint/ESLint note

The repo's ESLint config (`.eslintrc.js`) only extends the shared `custom/common` package; there is no server-local rule set. Adding a robust custom AST rule to flag optional-chained `where` filters in `deleteMany`/`updateMany` would be heavy and live outside this server. Per scope guidance, this PR instead documents the footgun and the required pattern as a clear code-comment convention next to `assertDefined`.

## Verification

- `tsc --noEmit` on `servers/curated-corpus-api`: clean (no errors).
- ESLint and the Jest test run were **not** executed here because the lint binary / shared config and Prisma client are not installed in this environment; CI should run them. The changes follow existing conventions and typecheck cleanly.
