### PR TITLE
fix(infra): increase curated-corpus-api Aurora backup retention to 7 days (HNT-2677)

### DIFF
--- a/infrastructure/curated-corpus-api/src/config/index.ts
+++ b/infrastructure/curated-corpus-api/src/config/index.ts
@@ -22,6 +22,11 @@ const rds = {
   // and changes should be considered.
   minCapacity: isDev ? 1 : 4,
   maxCapacity: isDev ? 2 : 128, // max allowed by AWS for Aurora Serverless V2
+  // Number of days Aurora retains automated backups and the continuous
+  // point-in-time-recovery (PITR) window. Unset defaults to 1 day, which left
+  // prod with a single backup and a one-day recovery window. 7 days gives more
+  // time to recover from data corruption that is not immediately apparent (HNT-2677).
+  backupRetentionPeriod: isDev ? 1 : 7,
 };
 
 export const config = {

--- a/infrastructure/curated-corpus-api/src/main.ts
+++ b/infrastructure/curated-corpus-api/src/main.ts
@@ -161,6 +161,7 @@ class CuratedCorpusAPI extends TerraformStack {
         engine: 'aurora-mysql',
         engineMode: 'provisioned',
         engineVersion: '8.0.mysql_aurora.3.06.0',
+        backupRetentionPeriod: config.rds.backupRetentionPeriod,
         serverlessv2ScalingConfiguration: {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,


### PR DESCRIPTION
## Goal

The prod curated-corpus-api Aurora cluster had no `backupRetentionPeriod` set, so it used the AWS default of 1 day, resulting in a single automated backup. This PR raises it to 7 days such that we have more time to recover data, in case data corruption is not immediately apparent. Dev stays at 1 day.

## Deployment steps

This can simply be merged in, without any service interruption.

> **Important**
> An outage occurs if you change the backup retention period of a DB instance from 0 to a nonzero value or from a nonzero value to 0.

Source: [Backup retention period — Amazon RDS User Guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.BackupRetention.html)

## References

JIRA ticket:

- https://mozilla-hub.atlassian.net/browse/HNT-2677
