### PR TITLE
fix(corpus-api): make ML re-add of manually-removed SectionItem a no-op (HNT-2681)

### DIFF
--- a/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
+++ b/lambdas/section-manager-lambda/src/graphQlApiCalls.ts
@@ -166,13 +166,15 @@ export async function createApprovedCorpusItem(
  * @param adminApiEndpoint  string
  * @param graphHeaders GraphQlApiHeaders object
  * @param data CreateSectionItemApiInput
- * @returns Promise<string> - externalId of the created SectionItem
+ * @returns Promise<string | null> - externalId of the created SectionItem, or
+ *   null when the mutation is a no-op (e.g. ML re-adding an item an editor
+ *   previously removed manually)
  */
 export async function createSectionItem(
   adminApiEndpoint: string,
   graphHeaders: GraphQlApiCallHeaders,
   data: CreateSectionItemApiInput,
-): Promise<string> {
+): Promise<string | null> {
   await sleep(config.app.graphQLSleep);
 
   const mutation = `
@@ -201,7 +203,8 @@ export async function createSectionItem(
     );
   }
 
-  return result.data.createSectionItem.externalId;
+  // The server returns null (not an error) when ML re-adds a manually-removed item.
+  return result.data.createSectionItem?.externalId ?? null;
 }
 
 /**

--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -570,6 +570,36 @@ describe('utils', () => {
       );
     });
 
+    it('treats a createSectionItem no-op (null) as skipped, not a failure', async () => {
+      // all items already exist in the corpus
+      jest.spyOn(GraphQlApiCalls, 'getApprovedCorpusItemByUrl').mockResolvedValue(
+        {
+          externalId: 'approvedItemExternalId1',
+          url: 'test.com',
+        },
+      );
+
+      // createSectionItem returns null for the second candidate, simulating an
+      // item an editor previously removed manually (HNT-2681 no-op).
+      mockCreateSectionItem
+        .mockResolvedValueOnce('sectionItemExternalId1')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('sectionItemExternalId3');
+
+      await Utils.processSqsSectionData(sqsSectionData, jwtBearerToken);
+
+      expect(mockCreateSectionItem).toHaveBeenCalledTimes(sectionItemCount);
+
+      // a no-op is not an error: nothing captured/logged as a failure
+      expect(sentryStub).toHaveBeenCalledTimes(0);
+      expect(mockConsoleError).toHaveBeenCalledTimes(0);
+
+      // the no-op candidate is counted as neither succeeded nor failed
+      expect(mockConsoleLog.mock.calls[1][0]).toContain(
+        'processSqsSectionData result: 2 succeeded, 0 failed',
+      );
+    });
+
     it('calls the expected functions when creating ML SectionItems first, ignoring dupes, then removing old SectionItems, with deactivateSource=ML', async () => {
       const url1 = 'https://example-one.com';
       const url2 = 'https://example-two.com';

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -144,6 +144,11 @@ export const processSqsSectionData = async (
           rank: sqsSectionItem.rank,
         },
       );
+      // A null result is an expected no-op (manually-removed item), so skip it
+      // without counting it as a failure.
+      if (newSectionItemExternalId === null) {
+        continue;
+      }
       // Mark URL as active to prevent duplicate creation
       // ML should not be sending duplicate candidate URLs within a Section within the same run
       // this is a safe guard

--- a/servers/curated-corpus-api/schema-admin.graphql
+++ b/servers/curated-corpus-api/schema-admin.graphql
@@ -1403,8 +1403,10 @@ type Mutation {
 
   """
   Creates a SectionItem within a Section.
+  Returns null (a no-op) when an ML-automated process attempts to re-add an
+  item that an editor previously removed manually.
   """
-  createSectionItem(data: CreateSectionItemInput!): SectionItem!
+  createSectionItem(data: CreateSectionItemInput!): SectionItem
 
   """
   Updates a SectionItem's mutable fields (e.g. rank).

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/createSectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/createSectionItem.integration.ts
@@ -246,7 +246,7 @@ describe('mutations: SectionItem (createSectionItem)', () => {
     );
   });
 
-  it('should block ML from re-adding a manually removed item', async () => {
+  it('should no-op (return null, no error) when ML re-adds a manually removed item', async () => {
     // First, manually remove an item from a section
     await db.sectionItem.create({
       data: {
@@ -286,12 +286,16 @@ describe('mutations: SectionItem (createSectionItem)', () => {
         variables: { data: input },
       });
 
-    // Should have a FORBIDDEN error
-    expect(result.body.errors).not.toBeUndefined();
-    expect(result.body.errors?.[0].extensions?.code).toEqual('FORBIDDEN');
-    expect(result.body.errors?.[0].message).toContain(
-      'Cannot create section item: This item was previously removed manually and cannot be re-added by ML.',
-    );
+    // Should be a no-op: no error surfaced (so it never reaches the admin-api
+    // gateway alert, HNT-2681) and createSectionItem resolves to null.
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body.data?.createSectionItem).toBeNull();
+
+    // confirm nothing was created in section2
+    const created = await db.sectionItem.findFirst({
+      where: { approvedItemId: approvedItem.id, sectionId: section2.id },
+    });
+    expect(created).toBeNull();
   });
 
   it('should allow manual users to re-add a manually removed item', async () => {

--- a/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/mutations/SectionItem/index.ts
@@ -25,7 +25,7 @@ export async function createSectionItem(
   parent,
   { data },
   context: IAdminContext,
-): Promise<SectionItem> {
+): Promise<SectionItem | null> {
   const { actionScreen, ...createData } = data;
 
   // find the targeted Section so we can verify user has write access to its Scheduled Surface
@@ -62,6 +62,12 @@ export async function createSectionItem(
     },
     createSource,
   );
+
+  // dbCreateSectionItem returns null on the expected ML re-add no-op; nothing
+  // was created, so skip the event and return null.
+  if (!sectionItem) {
+    return null;
+  }
 
   const sectionItemForEvents: SectionItemPayload = {
     sectionItem: {

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.integration.ts
@@ -46,7 +46,7 @@ describe('SectionItem', () => {
       expect(result.approvedItemId).toEqual(approvedItem.id);
     });
 
-    it('should block ML from re-adding a manually removed item', async () => {
+    it('should no-op (return null) when ML re-adds a manually removed item', async () => {
       const approvedItem = await createApprovedItemHelper(db, {
         title: 'Test Item',
       });
@@ -67,19 +67,26 @@ describe('SectionItem', () => {
         },
       });
 
-      // ML should be blocked from adding this item to ANY section
-      await expect(
-        createSectionItem(
-          db,
-          {
-            sectionId: section2.id,
-            approvedItemExternalId: approvedItem.externalId,
-          },
-          ActivitySource.ML,
-        ),
-      ).rejects.toThrow(
-        'Cannot create section item: This item was previously removed manually and cannot be re-added by ML.',
+      // ML should be blocked from adding this item to ANY section; the guard
+      // is not scoped to a single section, so removal from section1 blocks
+      // re-adding to section2. This is an expected no-op (returns null), not
+      // an error (HNT-2681).
+      const result = await createSectionItem(
+        db,
+        {
+          sectionId: section2.id,
+          approvedItemExternalId: approvedItem.externalId,
+        },
+        ActivitySource.ML,
       );
+
+      expect(result).toBeNull();
+
+      // confirm nothing was created in section2
+      const created = await db.sectionItem.findFirst({
+        where: { approvedItemId: approvedItem.id, sectionId: section2.id },
+      });
+      expect(created).toBeNull();
     });
 
     it('should allow manual users to re-add a manually removed item', async () => {

--- a/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
+++ b/servers/curated-corpus-api/src/database/mutations/SectionItem.ts
@@ -1,4 +1,5 @@
-import { NotFoundError, ForbiddenError } from '@pocket-tools/apollo-utils';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
+import { serverLogger } from '@pocket-tools/ts-logger';
 
 import { PrismaClient } from '.prisma/client';
 
@@ -16,12 +17,14 @@ import { ActivitySource } from 'content-common';
  * @param db
  * @param data
  * @param createSource - The source creating the section item (ML or MANUAL)
+ * @returns the created SectionItem, or null when ML attempts to re-add an item
+ *   that an editor previously removed manually (an expected no-op, not an error)
  */
 export async function createSectionItem(
   db: PrismaClient,
   data: CreateSectionItemInput,
   createSource: ActivitySource = ActivitySource.MANUAL,
-): Promise<SectionItem> {
+): Promise<SectionItem | null> {
   // we verify the Section/sectionId in the upstream resolver, so no need to
   // do so again here
   const { sectionId, approvedItemExternalId, rank } = data;
@@ -37,7 +40,9 @@ export async function createSectionItem(
     );
   }
 
-  // Check if ML is trying to add an item that was manually removed
+  // ML's dataset lags the corpus (data lake latency), so ML re-adding an item
+  // an editor removed manually is expected. Treat it as a no-op: log and
+  // return null instead of throwing an error (HNT-2681).
   if (createSource === ActivitySource.ML) {
     const manuallyRemovedItem = await db.sectionItem.findFirst({
       where: {
@@ -48,9 +53,14 @@ export async function createSectionItem(
     });
 
     if (manuallyRemovedItem) {
-      throw new ForbiddenError(
-        `Cannot create section item: This item was previously removed manually and cannot be re-added by ML.`,
+      serverLogger.info(
+        'Skipping ML re-add of a SectionItem that was previously removed manually',
+        {
+          approvedItemExternalId,
+          sectionId,
+        },
       );
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary

Stops the `hnt-admin-api` error alert noise (HNT-ADMIN-API-2 umbrella) caused by ML re-attempting SectionItems that editors removed manually.

When ML tries to re-add such an item, `curated-corpus-api` threw a `ForbiddenError`. The admin-api federation gateway re-codes that downstream error as `downstreamServiceError`, so it surfaced in the admin-api Sentry alert **and** was re-captured in section-manager-lambda's own Sentry.

Per [Slack thread](https://mozilla.slack.com/archives/C09PBCCN0M6/p1781300555784519?thread_ts=1781271168.213089&cid=C09PBCCN0M6), this is expected behavior, not an actionable error: ML's dataset lags the corpus due to data lake latency. So we capture it as a log statement and not an error.

<img width="686" height="359" alt="image" src="https://github.com/user-attachments/assets/51cbe9a4-ff31-4189-9f73-1c3b4be658c1" />


## Changes

**curated-corpus-api**
- `createSectionItem` returns `null` (logged at `info`) instead of throwing `ForbiddenError`.
- Schema field `createSectionItem(...): SectionItem` is now nullable.
- Resolver skips the `ADD_SECTION_ITEM` event on a no-op.

**section-manager-lambda**
- Wrapper returns `string | null`; the loop treats `null` as skipped.