### PR TITLE
fix(section-manager): skip candidates without a usable image instead of erroring (HNT-2757)

### DIFF
--- a/lambdas/section-manager-lambda/src/utils.spec.ts
+++ b/lambdas/section-manager-lambda/src/utils.spec.ts
@@ -10,10 +10,7 @@ import {
   Topics,
   IABMetadata,
 } from 'content-common';
-import {
-  mapAuthorToApprovedItemAuthor,
-  mockPocketImageCache,
-} from 'lambda-common';
+import { mapAuthorToApprovedItemAuthor } from 'lambda-common';
 
 import * as GraphQlApiCalls from './graphQlApiCalls';
 import { createSqsSectionWithSectionItems } from './testHelpers';
@@ -93,8 +90,6 @@ describe('utils', () => {
 
   describe('mapSqsSectionItemToCreateApprovedItemApiInput', () => {
     it('should map SQS values correctly', async () => {
-      mockPocketImageCache(200);
-
       const result = await Utils.mapSqsSectionItemToCreateApprovedItemApiInput(
         sqsSectionItem,
       );
@@ -121,31 +116,26 @@ describe('utils', () => {
     });
 
     it('should use empty array for authors when not provided', async () => {
-      mockPocketImageCache(200);
-
       sqsSectionItem.authors = null;
 
       const result = await Utils.mapSqsSectionItemToCreateApprovedItemApiInput(
         sqsSectionItem,
       );
 
-      expect(result.authors).toEqual([]);
+      expect(result!.authors).toEqual([]);
     });
 
     it('should omit datePublished when date_published is null', async () => {
-      mockPocketImageCache(200);
-
       sqsSectionItem.date_published = null;
 
       const result = await Utils.mapSqsSectionItemToCreateApprovedItemApiInput(
         sqsSectionItem,
       );
 
-      expect(result.datePublished).toBeUndefined();
+      expect(result!.datePublished).toBeUndefined();
     });
 
     it('should omit datePublished and log error when date_published is invalid', async () => {
-      mockPocketImageCache(200);
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
@@ -156,7 +146,7 @@ describe('utils', () => {
         sqsSectionItem,
       );
 
-      expect(result.datePublished).toBeUndefined();
+      expect(result!.datePublished).toBeUndefined();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('Invalid date_published "invalid-date"'),
       );
@@ -169,8 +159,6 @@ describe('utils', () => {
      * expected type.
      */
     it('should fail if SQS does not have required data', async () => {
-      mockPocketImageCache(200);
-
       sqsSectionItem.title = null;
 
       await expect(
@@ -187,12 +175,11 @@ describe('utils', () => {
      * its type validation.
      */
     it('should fail with a Typia error if all optional source data is missing', async () => {
-      mockPocketImageCache(200);
-
       // remove all optional SQS data
       sqsSectionItem.authors = null;
       sqsSectionItem.excerpt = null;
-      sqsSectionItem.image_url = null;
+      // keep a valid image_url so the typia assert (not the graceful image skip)
+      // is what rejects the other missing required fields below
       sqsSectionItem.language = null;
       sqsSectionItem.title = null;
 
@@ -213,8 +200,6 @@ describe('utils', () => {
 
     describe('formatting titles and excerpts', () => {
       beforeEach(() => {
-        mockPocketImageCache(200);
-
         // note - ideally we'd just spy on the internal functions, but there's
         // no easy way (afaik) to do that when importing from an external
         // module.
@@ -233,10 +218,10 @@ describe('utils', () => {
             sqsSectionItem,
           );
 
-        expect(result.title).toEqual(
+        expect(result!.title).toEqual(
           formatQuotesEN(sqsSectionItem.title as string),
         );
-        expect(result.excerpt).toEqual(
+        expect(result!.excerpt).toEqual(
           formatQuotesEN(sqsSectionItem.excerpt as string),
         );
       });
@@ -249,10 +234,10 @@ describe('utils', () => {
             sqsSectionItem,
           );
 
-        expect(result.title).toEqual(
+        expect(result!.title).toEqual(
           formatQuotesDashesDE(sqsSectionItem.title as string),
         );
-        expect(result.excerpt).toEqual(
+        expect(result!.excerpt).toEqual(
           formatQuotesDashesDE(sqsSectionItem.excerpt as string),
         );
       });
@@ -265,21 +250,36 @@ describe('utils', () => {
             sqsSectionItem,
           );
 
-        expect(result.title).toEqual(sqsSectionItem.title as string);
-        expect(result.excerpt).toEqual(sqsSectionItem.excerpt as string);
+        expect(result!.title).toEqual(sqsSectionItem.title as string);
+        expect(result!.excerpt).toEqual(sqsSectionItem.excerpt as string);
       });
     });
 
-    it('should fail if image validation fails', async () => {
-      mockPocketImageCache(500);
+    it('returns null (skip) when image_url is missing — images are required for New Tab', async () => {
+      const consoleLogSpy = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+      sqsSectionItem.image_url = null;
 
-      await expect(
-        Utils.mapSqsSectionItemToCreateApprovedItemApiInput(sqsSectionItem),
-      ).rejects.toThrow(
-        new Error(
-          `Error on assert(): invalid type on $input.imageUrl, expect to be string`,
-        ),
+      const result = await Utils.mapSqsSectionItemToCreateApprovedItemApiInput(
+        sqsSectionItem,
       );
+
+      expect(result).toBeNull();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no image_url provided by ML'),
+      );
+    });
+
+    it('returns null (skip) when image_url is an empty string', async () => {
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      sqsSectionItem.image_url = '';
+
+      const result = await Utils.mapSqsSectionItemToCreateApprovedItemApiInput(
+        sqsSectionItem,
+      );
+
+      expect(result).toBeNull();
     });
   });
 
@@ -572,12 +572,12 @@ describe('utils', () => {
 
     it('treats a createSectionItem no-op (null) as skipped, not a failure', async () => {
       // all items already exist in the corpus
-      jest.spyOn(GraphQlApiCalls, 'getApprovedCorpusItemByUrl').mockResolvedValue(
-        {
+      jest
+        .spyOn(GraphQlApiCalls, 'getApprovedCorpusItemByUrl')
+        .mockResolvedValue({
           externalId: 'approvedItemExternalId1',
           url: 'test.com',
-        },
-      );
+        });
 
       // createSectionItem returns null for the second candidate, simulating an
       // item an editor previously removed manually (HNT-2681 no-op).
@@ -597,6 +597,34 @@ describe('utils', () => {
       // the no-op candidate is counted as neither succeeded nor failed
       expect(mockConsoleLog.mock.calls[1][0]).toContain(
         'processSqsSectionData result: 2 succeeded, 0 failed',
+      );
+    });
+
+    it('skips a candidate with no usable image (mapper returns null) without counting it as a failure', async () => {
+      // none of the items exist in the corpus, so each goes through the create path
+      jest
+        .spyOn(GraphQlApiCalls, 'getApprovedCorpusItemByUrl')
+        .mockResolvedValue(null);
+
+      // the second candidate has no usable image -> mapper returns null (skip)
+      mockMapSqsSectionItemToCreateApprovedItemApiInput
+        .mockResolvedValueOnce({} as CreateApprovedCorpusItemApiInput)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({} as CreateApprovedCorpusItemApiInput);
+
+      await Utils.processSqsSectionData(sqsSectionData, jwtBearerToken);
+
+      // create is only attempted for the 2 candidates that have an image
+      expect(mockCreateApprovedCorpusItem).toHaveBeenCalledTimes(
+        sectionItemCount - 1,
+      );
+      expect(mockCreateSectionItem).toHaveBeenCalledTimes(sectionItemCount - 1);
+
+      // a skip is not an error
+      expect(sentryStub).toHaveBeenCalledTimes(0);
+      expect(mockConsoleError).toHaveBeenCalledTimes(0);
+      expect(mockConsoleLog.mock.calls[1][0]).toContain(
+        'processSqsSectionData result: 2 succeeded, 0 failed, 1 skipped',
       );
     });
 

--- a/lambdas/section-manager-lambda/src/utils.ts
+++ b/lambdas/section-manager-lambda/src/utils.ts
@@ -15,7 +15,6 @@ import {
   GraphQlApiCallHeaders,
   mapAuthorToApprovedItemAuthor,
   validateDatePublished,
-  validateImageUrl,
 } from 'lambda-common';
 
 import config from './config';
@@ -75,9 +74,11 @@ export const processSqsSectionData = async (
     ]),
   );
 
-  // keep track of how many candidates succeeded, how many failed
+  // keep track of how many candidates succeeded, failed, or were skipped
   let successfulCandidates = 0;
   let failedCandidates = 0;
+  // candidates skipped as an expected no-op (e.g. no usable image); not failures
+  let skippedCandidates = 0;
 
   // Get the existing SectionItems to remove from a Section
   const sectionItemsToRemove = computeSectionItemsToRemove(
@@ -124,6 +125,14 @@ export const processSqsSectionData = async (
         const apiInput = await mapSqsSectionItemToCreateApprovedItemApiInput(
           sqsSectionItem,
         );
+
+        // A null result means the candidate has no usable image. Images are
+        // required to display a recommendation on New Tab, so treat this as an
+        // expected skip (not a failure) rather than throwing downstream.
+        if (apiInput === null) {
+          skippedCandidates++;
+          continue;
+        }
 
         // create the ApprovedItem
         approvedItemExternalId = await createApprovedCorpusItem(
@@ -187,7 +196,7 @@ export const processSqsSectionData = async (
   }
 
   console.log(
-    `processSqsSectionData result: ${successfulCandidates} succeeded, ${failedCandidates} failed`,
+    `processSqsSectionData result: ${successfulCandidates} succeeded, ${failedCandidates} failed, ${skippedCandidates} skipped (no image)`,
   );
 };
 
@@ -242,7 +251,7 @@ export const mapSqsSectionDataToCreateOrUpdateSectionApiInput = (
  */
 export const mapSqsSectionItemToCreateApprovedItemApiInput = async (
   sqsSectionItem: SqsSectionItem,
-): Promise<CreateApprovedCorpusItemApiInput> => {
+): Promise<CreateApprovedCorpusItemApiInput | null> => {
   // source and topic are required from ML & have been validated upstream
   const source = sqsSectionItem.source;
   const topic = sqsSectionItem.topic;
@@ -264,9 +273,25 @@ export const mapSqsSectionItemToCreateApprovedItemApiInput = async (
     excerpt = excerpt && formatQuotesDashesDE(excerpt);
   }
 
-  let imageUrl: string | undefined = sqsSectionItem.image_url ?? undefined;
-  // only validate the imageUrl if it's defined
-  imageUrl = imageUrl && (await validateImageUrl(imageUrl));
+  // Images are required to render a recommendation on Firefox New Tab. ML
+  // sometimes sends candidates without one (image_url null/empty); previously
+  // every such item threw a typia assert error (~2,800/day) and was dropped as
+  // a "failure". Treat a missing image as an expected skip instead (HNT-2757).
+  //
+  // We intentionally no longer pre-validate a present image via the
+  // pocket-image-cache proxy: that proxy returns false negatives for images
+  // that are directly fetchable (e.g. ilsole24ore.com returns 200 directly but
+  // 500 through the proxy), so it dropped valid items. It is also redundant
+  // with curated-corpus-api, which fetches and uploads the image itself;
+  // genuine fetch failures surface there instead (see HNT-2758).
+  const imageUrl: string | undefined =
+    sqsSectionItem.image_url?.trim() || undefined;
+  if (!imageUrl) {
+    console.log(
+      `Skipping section item candidate for URL ${sqsSectionItem.url}: no image_url provided by ML (images are required for New Tab)`,
+    );
+    return null;
+  }
 
   // Validate date_published from ML; drop if invalid
   const datePublished = validateDatePublished(sqsSectionItem.date_published);


### PR DESCRIPTION
## Summary
Fixes [HNT-2757](https://mozilla-hub.atlassian.net/browse/HNT-2757). The Section Manager lambda was dropping ~2,800 section-item candidates/day with a client-side `TypeGuardError: invalid type on $input.imageUrl, expect to be string, value: undefined` (thrown by the typia `assert` in `mapSqsSectionItemToCreateApprovedItemApiInput`). Because it throws before calling admin-api it is invisible to the hnt-admin-api error alert, but it is the single largest section-ingestion failure (~79% of that lambda's ~3.5% failure rate).

Two root causes, both addressed:
1. **ML sends candidates with no image** (`image_url: null`/empty). The ML model treats `image_url` as optional; a strict downstream assert then turned every image-less candidate into a hard error. That is expected data, not an actionable failure.
2. **A present image is wrongly rejected** by `validateImageUrl`, which routes through the pocket-image-cache (Thumbor) proxy and drops the item if the proxy responds non-OK.

## Reproduction (local `fetch`)
| Host (from prod failures) | direct fetch | + browser UA | pocket-image-cache proxy (`validateImageUrl`) |
|---|---|---|---|
| ilsole24ore.com | **200** | 200 | **500** |
| pap.pl | 200 | 200 | **400** |
| image.ie | 403 | 403 | 404 |
| rollingstone.de / ppe.pl | 200 | 200 | 200 |

`ilsole24ore.com` images are directly fetchable (200) but the proxy returns 500, so `validateImageUrl` rejected valid items. A User-Agent does not help (the failure is proxy-side). Some hosts (image.ie) block all datacenter fetches regardless.

## Change
- `image_url` missing/empty → skip the candidate as an expected no-op (info log; counted as `skipped`, not `failed`). **Images remain required**, so image-less items are still not created.
- Removed the `validateImageUrl` (pocket-image-cache) pre-check for a present image. It produced false negatives (above) and is redundant with curated-corpus-api, which performs the authoritative image fetch + S3 upload. Genuine unfetchable images (e.g. image.ie) now surface at that layer as the "Could not generate an S3 URL" error tracked by **HNT-2758**, instead of as a silent section-manager crash.
- Added a `skipped` count to the run summary log.

## Trade-off / scope
This converts silent, noisy section-manager drops into either (a) recovered items (proxy false-negatives like ilsole24ore) or (b) failures surfaced at the authoritative curated-corpus-api/S3 layer (HNT-2758). Net: fewer total drops and no more `TypeGuardError` noise; a portion of genuinely-unfetchable images shifts to HNT-2758, where coarse handling of that error is being addressed separately. Scoped to section-manager; corpus-scheduler is unchanged (it shares `validateImageUrl` but has ~0 such failures).

## Test plan
- `npx tsc --noEmit` — clean.
- `utils.spec.ts` — 23/23 pass, incl. new tests: mapper returns `null` (skip) on null/empty image; `processSqsSectionData` counts a no-image candidate as skipped, not failed.
- `index.spec.ts` — pass.
- Note: 2 failures in `validators.spec.ts` are **pre-existing on `main`** (reproduce with this branch stashed; that file imports `./validators`, not `utils.ts`; likely a typia/Node-24 local-env quirk), not introduced here.

Refs: HNT-2757 (this), HNT-2758 (S3 image fetch handling).


[HNT-2757]: https://mozilla-hub.atlassian.net/browse/HNT-2757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ