### PR TITLE
feat: add en-XE (cross-Europe English) and es-XA (cross-Latin America Spanish) surfaces

### DIFF
--- a/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
+++ b/lambdas/corpus-scheduler-lambda/src/validation.spec.ts
@@ -264,7 +264,7 @@ describe('validation', function () {
       expect(() => {
         validateCandidate(badScheduledCandidate);
       }).toThrow(
-        'Error on assert(): invalid type on $input.scheduled_corpus_item.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_ES_ES" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
+        'Error on assert(): invalid type on $input.scheduled_corpus_item.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_EN_XE" | "NEW_TAB_ES_ES" | "NEW_TAB_ES_XA" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
       );
     });
 

--- a/lambdas/section-manager-lambda/src/validators.spec.ts
+++ b/lambdas/section-manager-lambda/src/validators.spec.ts
@@ -79,7 +79,7 @@ describe('validation', function () {
         expect(() => {
           validateSqsData(sqsData);
         }).toThrow(
-          'Error on assert(): invalid type on $input.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_ES_ES" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
+          'Error on assert(): invalid type on $input.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_EN_XE" | "NEW_TAB_ES_ES" | "NEW_TAB_ES_XA" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
         );
 
         // scheduled surface has an invalid value
@@ -89,7 +89,7 @@ describe('validation', function () {
         expect(() => {
           validateSqsData(sqsData);
         }).toThrow(
-          'Error on assert(): invalid type on $input.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_ES_ES" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
+          'Error on assert(): invalid type on $input.scheduled_surface_guid, expect to be ("NEW_TAB_DE_AT" | "NEW_TAB_DE_CH" | "NEW_TAB_DE_DE" | "NEW_TAB_EN_CA" | "NEW_TAB_EN_GB" | "NEW_TAB_EN_IE" | "NEW_TAB_EN_INT" | "NEW_TAB_EN_US" | "NEW_TAB_EN_XE" | "NEW_TAB_ES_ES" | "NEW_TAB_ES_XA" | "NEW_TAB_FR_BE" | "NEW_TAB_FR_FR" | "NEW_TAB_IT_IT" | "NEW_TAB_PL_PL" | "POCKET_HITS_DE_DE" | "POCKET_HITS_EN_US" | "SANDBOX")',
         );
       });
 

--- a/packages/content-common/src/types.ts
+++ b/packages/content-common/src/types.ts
@@ -282,10 +282,12 @@ export enum ScheduledSurfacesEnum {
   NEW_TAB_EN_GB = 'NEW_TAB_EN_GB',
   NEW_TAB_EN_CA = 'NEW_TAB_EN_CA',
   NEW_TAB_EN_IE = 'NEW_TAB_EN_IE',
+  NEW_TAB_EN_XE = 'NEW_TAB_EN_XE',
   NEW_TAB_FR_FR = 'NEW_TAB_FR_FR',
   NEW_TAB_FR_BE = 'NEW_TAB_FR_BE',
   NEW_TAB_IT_IT = 'NEW_TAB_IT_IT',
   NEW_TAB_ES_ES = 'NEW_TAB_ES_ES',
+  NEW_TAB_ES_XA = 'NEW_TAB_ES_XA',
   NEW_TAB_PL_PL = 'NEW_TAB_PL_PL',
   NEW_TAB_EN_INT = 'NEW_TAB_EN_INT',
   POCKET_HITS_EN_US = 'POCKET_HITS_EN_US',
@@ -305,10 +307,12 @@ export enum MozillaAccessGroup {
   NEW_TAB_CURATOR_ENGB = 'mozilliansorg_pocket_new_tab_curator_engb', // Access to en-GB new tab in corpus tool.
   NEW_TAB_CURATOR_ENCA = 'mozilliansorg_pocket_new_tab_curator_enca', // Access to en-CA new tab in corpus tool.
   NEW_TAB_CURATOR_ENIE = 'mozilliansorg_pocket_new_tab_curator_enie', // Access to en-IE new tab in corpus tool.
+  NEW_TAB_CURATOR_ENXE = 'mozilliansorg_pocket_new_tab_curator_enxe', // Access to en-XE (cross-Europe English) new tab in corpus tool.
   NEW_TAB_CURATOR_FRFR = 'mozilliansorg_pocket_new_tab_curator_frfr', // Access to fr-FR new tab in corpus tool.
   NEW_TAB_CURATOR_FRBE = 'mozilliansorg_pocket_new_tab_curator_frbe', // Access to fr-BE new tab in corpus tool.
   NEW_TAB_CURATOR_ITIT = 'mozilliansorg_pocket_new_tab_curator_itit', // Access to it-IT new tab in corpus tool.
   NEW_TAB_CURATOR_ESES = 'mozilliansorg_pocket_new_tab_curator_eses', // Access to es-ES new tab in corpus tool.
+  NEW_TAB_CURATOR_ESXA = 'mozilliansorg_pocket_new_tab_curator_esxa', // Access to es-XA (cross-Latin America Spanish) new tab in corpus tool.
   NEW_TAB_CURATOR_PLPL = 'mozilliansorg_pocket_new_tab_curator_plpl', // Access to pl-PL new tab in corpus tool.
   NEW_TAB_CURATOR_ENINTL = 'mozilliansorg_pocket_new_tab_curator_enintl', // Access to en-INTL new tab in corpus tool.
   POCKET_HITS_CURATOR_ENUS = 'mozilliansorg_pocket_pocket_hits_curator_enus', // Access to en us Pocket Hits in the corpus tool.
@@ -415,6 +419,13 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ENIE,
   },
   {
+    name: 'New Tab (EN Europe)',
+    guid: 'NEW_TAB_EN_XE',
+    ianaTimezone: 'Europe/Berlin',
+    prospectTypes: [],
+    accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ENXE,
+  },
+  {
     name: 'New Tab (fr-FR)',
     guid: 'NEW_TAB_FR_FR',
     ianaTimezone: 'Europe/Paris',
@@ -453,6 +464,13 @@ export const ScheduledSurfaces: ScheduledSurface[] = [
       ProspectType.PUBLISHER_SUBMITTED,
     ],
     accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ESES,
+  },
+  {
+    name: 'New Tab (ES Global)',
+    guid: 'NEW_TAB_ES_XA',
+    ianaTimezone: 'America/Mexico_City',
+    prospectTypes: [],
+    accessGroup: MozillaAccessGroup.NEW_TAB_CURATOR_ESXA,
   },
   {
     name: 'New Tab (pl-PL)',

--- a/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
+++ b/servers/curated-corpus-api/src/shared/resolvers/fields/SectionStatus.spec.ts
@@ -10,10 +10,12 @@ const testSurfacesTimeZones = [
   { guid: 'NEW_TAB_EN_GB',   timezone: 'Europe/London' },
   { guid: 'NEW_TAB_EN_CA',   timezone: 'America/Toronto' },
   { guid: 'NEW_TAB_EN_IE',   timezone: 'Europe/Dublin' },
+  { guid: 'NEW_TAB_EN_XE',   timezone: 'Europe/Berlin' },
   { guid: 'NEW_TAB_FR_FR',   timezone: 'Europe/Paris' },
   { guid: 'NEW_TAB_FR_BE',   timezone: 'Europe/Brussels' },
   { guid: 'NEW_TAB_IT_IT',   timezone: 'Europe/Rome' },
   { guid: 'NEW_TAB_ES_ES',   timezone: 'Europe/Madrid' },
+  { guid: 'NEW_TAB_ES_XA',   timezone: 'America/Mexico_City' },
   { guid: 'NEW_TAB_PL_PL',   timezone: 'Europe/Warsaw' },
   { guid: 'NEW_TAB_EN_INTL', timezone: 'Asia/Kolkata' },
 ];

--- a/servers/prospect-api/src/types.ts
+++ b/servers/prospect-api/src/types.ts
@@ -40,8 +40,10 @@ export enum MozillaAccessGroup {
   NEW_TAB_CURATOR_ENGB = 'mozilliansorg_pocket_new_tab_curator_engb', // Access to en-gb new tab in corpus tool.
   NEW_TAB_CURATOR_ENCA = 'mozilliansorg_pocket_new_tab_curator_enca', // Access to en-ca new tab in corpus tool.
   NEW_TAB_CURATOR_ENIE = 'mozilliansorg_pocket_new_tab_curator_enie', // Access to en-ie new tab in corpus tool.
+  NEW_TAB_CURATOR_ENXE = 'mozilliansorg_pocket_new_tab_curator_enxe', // Access to en-xe (cross-Europe English) new tab in corpus tool.
   NEW_TAB_CURATOR_ENINTL = 'mozilliansorg_pocket_new_tab_curator_enintl', // Access to en-intl new tab in corpus tool.
   NEW_TAB_CURATOR_ESES = 'mozilliansorg_pocket_new_tab_curator_eses', // Access to es-es new tab in the corpus tool.
+  NEW_TAB_CURATOR_ESXA = 'mozilliansorg_pocket_new_tab_curator_esxa', // Access to es-xa (cross-Latin America Spanish) new tab in the corpus tool.
   NEW_TAB_CURATOR_FRFR = 'mozilliansorg_pocket_new_tab_curator_frfr', // Access to fr-fr new tab in the corpus tool.
   NEW_TAB_CURATOR_FRBE = 'mozilliansorg_pocket_new_tab_curator_frbe', // Access to fr-be new tab in the corpus tool.
   NEW_TAB_CURATOR_ITIT = 'mozilliansorg_pocket_new_tab_curator_itit', // Access to it-it new tab in the corpus tool.
@@ -57,11 +59,13 @@ export enum ScheduledSurfaceGuidToMozillaAccessGroup {
   NEW_TAB_EN_GB = MozillaAccessGroup.NEW_TAB_CURATOR_ENGB,
   NEW_TAB_EN_CA = MozillaAccessGroup.NEW_TAB_CURATOR_ENCA,
   NEW_TAB_EN_IE = MozillaAccessGroup.NEW_TAB_CURATOR_ENIE,
+  NEW_TAB_EN_XE = MozillaAccessGroup.NEW_TAB_CURATOR_ENXE,
   NEW_TAB_EN_INTL = MozillaAccessGroup.NEW_TAB_CURATOR_ENINTL,
   NEW_TAB_DE_DE = MozillaAccessGroup.NEW_TAB_CURATOR_DEDE,
   NEW_TAB_DE_AT = MozillaAccessGroup.NEW_TAB_CURATOR_DEAT,
   NEW_TAB_DE_CH = MozillaAccessGroup.NEW_TAB_CURATOR_DECH,
   NEW_TAB_ES_ES = MozillaAccessGroup.NEW_TAB_CURATOR_ESES,
+  NEW_TAB_ES_XA = MozillaAccessGroup.NEW_TAB_CURATOR_ESXA,
   NEW_TAB_FR_FR = MozillaAccessGroup.NEW_TAB_CURATOR_FRFR,
   NEW_TAB_FR_BE = MozillaAccessGroup.NEW_TAB_CURATOR_FRBE,
   NEW_TAB_IT_IT = MozillaAccessGroup.NEW_TAB_CURATOR_ITIT,


### PR DESCRIPTION
## Goal

Add scheduled surfaces for **cross-Europe English (`en_XE` → `NEW_TAB_EN_XE`)** and **Global America Spanish (`es_XA` → `NEW_TAB_ES_XA`)**, so we can enable ML sections for these two new markets.

GUIDs and locales match the ML pipeline in [mozilla/content-ml-services#1243](https://github.com/mozilla/content-ml-services/pull/1243). Both languages (EN, ES) already exist in the `CorpusLanguage` enum, so no language changes are needed.

**Timezones** drive `computeSectionStatus` (the live/scheduled/expired day boundary in the curation tool), so they are chosen to be representative of each market: `en_XE` → `Europe/Berlin` (central Europe) and `es_XA` → `America/Mexico_City` (largest Spanish-speaking city in the Americas).

Follows the pattern of [#384](https://github.com/Pocket/content-monorepo/pull/384) (de-AT / de-CH / pl-PL / fr-BE).

## Companion PRs

- ML: [mozilla/content-ml-services#1243](https://github.com/mozilla/content-ml-services/pull/1243)
- Curation tool: [Pocket/curation-admin-tools#1279](https://github.com/Pocket/curation-admin-tools/pull/1279)

## Deployment steps

- [ ] Create a Mozilla Access Group for each new surface at [people.mozilla.org/a/](https://people.mozilla.org/a/): `mozilliansorg_pocket_new_tab_curator_enxe` and `mozilliansorg_pocket_new_tab_curator_esxa`. Without these, curators will get a 403 in the curation tool.
- [x] Merge and deploy the companion [curation-admin-tools#1279](https://github.com/Pocket/curation-admin-tools/pull/1279).

## QA

1. Push these changes to dev.
2. Create a custom section on dev for each new surface (e.g. `.../custom-sections/<externalId>/NEW_TAB_EN_XE/`).
3. Run `getSections` in the dev Apollo graph with each new `scheduledSurfaceGuid` and confirm the response contains the expected section items.

## References

- [Decision Document](https://docs.google.com/document/d/1ZucJUDI_MPVTtPkd3XuSD1XwZjIQvfffjyqzcPWE1Lc/edit?tab=t.0#heading=h.fks811ach14u)
- Documentation: [Creating a Scheduled Surface](https://mozilla-hub.atlassian.net/wiki/spaces/PE/pages/390649198/Creating+a+Scheduled+Surface)
