### PR TITLE
chore(graph): clean up graph schema:

### DIFF
--- a/servers/curated-corpus-api/schema-public.graphql
+++ b/servers/curated-corpus-api/schema-public.graphql
@@ -28,23 +28,8 @@ type ScheduledSurfaceItem {
   corpusItem: CorpusItem!
 }
 
-type SyndicatedArticle @key(fields: "slug") {
-  slug: String!
-}
-
-type Collection @key(fields: "slug") {
-  slug: String!
-}
-
-"""
-TODO: Make this type implement PocketResource when available.
-https://getpocket.atlassian.net/wiki/spaces/PE/pages/2771714049/The+Future+of+Item
-"""
-union CorpusTarget = SyndicatedArticle | Collection
-
 """
 Represents an item that is in the Corpus and its associated manually edited metadata.
-TODO: CorpusItem to implement PocketResource when it becomes available.
 """
 type CorpusItem @key(fields: "id") @key(fields: "url") {
   """
@@ -94,10 +79,6 @@ type CorpusItem @key(fields: "id") @key(fields: "url") {
   """
   topic: String
   """
-  If the Corpus Item is pocket owned with a specific type, this is the associated object (Collection or SyndicatedArticle).
-  """
-  target: CorpusTarget
-  """
   Experimental data point that could imply either an expiry date or an urgency to be shown.
   """
   isTimeSensitive: Boolean!
@@ -146,34 +127,4 @@ type Query {
   Retrieves a list of active and enabled Sections with their corresponding active SectionItems for a scheduled surface.
   """
   getSections(filters: SectionFilters!): [Section!]!
-}
-
-type SavedItem @key(fields: "url") {
-  """
-  key field to identify the SavedItem entity in the ListApi service
-  """
-  url: String!
-
-  """
-  If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
-  """
-  corpusItem: CorpusItem
-}
-
-type Item @key(fields: "givenUrl") {
-  """
-  key field to identify the CorpusItem entity in the RecsAPI service
-  """
-  givenUrl: Url!
-
-  """
-  Resolved URL field from the Parser in order to identify a given URL
-  in the Corpus (fallback if givenUrl is insufficient)
-  """
-  resolvedUrl: Url @external
-
-  """
-  If the item is in corpus allow the item to reference it.  Exposing curated info for consistent UX
-  """
-  corpusItem: CorpusItem @requires(fields: "resolvedUrl")
 }

--- a/servers/curated-corpus-api/src/database/types.ts
+++ b/servers/curated-corpus-api/src/database/types.ts
@@ -117,7 +117,7 @@ export type CreateSectionInput = {
   title: string;
   description?: string;
   scheduledSurfaceGuid: string;
-  iab?: IABMetadata,
+  iab?: IABMetadata;
   sort?: number;
   createSource: ActivitySource;
   active: boolean;
@@ -143,7 +143,7 @@ export type RemoveSectionItemInput = {
 export type DisableEnableSectionInput = {
   externalId: string;
   disabled: boolean;
-}
+};
 
 export type CreateCustomSectionInput = {
   title: string;
@@ -153,7 +153,7 @@ export type CreateCustomSectionInput = {
   startDate: string;
   endDate?: string;
   scheduledSurfaceGuid: string;
-  iab?: IABMetadata,
+  iab?: IABMetadata;
   sort?: number;
   createSource: ActivitySource;
   active: boolean;
@@ -190,19 +190,6 @@ export type Section = SectionModel & {
   sectionItems?: SectionItemModel[];
 };
 
-/**
- * CorpusTargetType probably makes more sense to be a union of all Pocket types
- * or entities. An incremental step in that direction was chosen. If we want to
- * expand this approach for more systems then we can figure out how to best
- * accomplish when that utility is defined.
- */
-export type CorpusTargetType = 'SyndicatedArticle' | 'Collection';
-
-export type CorpusTarget = {
-  slug: string;
-  __typename: CorpusTargetType;
-};
-
 // Types for the public `scheduledSurface` query.
 export type CorpusItem = {
   // This is `externalId` in the DB schema and Admin API
@@ -216,7 +203,6 @@ export type CorpusItem = {
   imageUrl: string;
   image: Image;
   topic?: string;
-  target?: CorpusTarget;
   isTimeSensitive: boolean;
 };
 

--- a/servers/curated-corpus-api/src/public/resolvers/index.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/index.ts
@@ -22,45 +22,9 @@ export const resolvers = {
       }
     },
   },
-  // Allow the `SavedItem` to resolve the corpus item
-  SavedItem: {
-    corpusItem: async (item, args, context: IPublicContext) => {
-      const corpusItem = await context.dataLoaders.corpusItemsByUrl.load(
-        item.url,
-      );
-
-      if (!corpusItem) {
-        return null;
-      }
-
-      return corpusItem;
-    },
-  },
   SectionItem: {
     corpusItem: (item) => {
       return getCorpusItemFromApprovedItem(item.approvedItem);
-    }
-  },
-  // Allow the `Item` to resolve the corpus item
-  Item: {
-    corpusItem: async (item, args, context: IPublicContext) => {
-      const { givenUrl, resolvedUrl } = item;
-
-      // try to get the corpusItem by the item's givenUrl
-      let corpusItem = await context.dataLoaders.corpusItemsByUrl.load(
-        givenUrl,
-      );
-
-      // if the item's givenUrl didn't return a corpusItem, and if the item has
-      // a resolvedUrl, try finding the corpusItem by resolvedUrl
-      if (!corpusItem && resolvedUrl) {
-        corpusItem = await context.dataLoaders.corpusItemsByUrl.load(
-          resolvedUrl,
-        );
-      }
-
-      // return the corpusItem or null
-      return corpusItem || null;
     },
   },
   Query: {

--- a/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/CorpusItem.integration.ts
@@ -4,10 +4,7 @@ import { ApolloServer } from '@apollo/server';
 import { PrismaClient } from '.prisma/client';
 import { client } from '../../../database/client';
 
-import {
-  CORPUS_ITEM_REFERENCE_RESOLVER,
-  CORPUS_ITEM_TARGET_REFERENCE_RESOLVER,
-} from './sample-queries.gql';
+import { CORPUS_ITEM_REFERENCE_RESOLVER } from './sample-queries.gql';
 import { clearDb, createApprovedItemHelper } from '../../../test/helpers';
 import { startServer } from '../../../express';
 import { IPublicContext } from '../../context';
@@ -23,8 +20,6 @@ describe('CorpusItem reference resolver', () => {
   let approvedItem2: ApprovedItem;
   let approvedItem3: ApprovedItem;
   let approvedItem4: ApprovedItem;
-  let approvedItemCollection: ApprovedItem;
-  let approvedItemSyndicated: ApprovedItem;
 
   beforeAll(async () => {
     // port 0 tells express to dynamically assign an available port
@@ -52,16 +47,6 @@ describe('CorpusItem reference resolver', () => {
 
     approvedItem4 = await createApprovedItemHelper(db, {
       title: 'Story four',
-    });
-
-    approvedItemSyndicated = await createApprovedItemHelper(db, {
-      title: 'Syndicated story one',
-      url: 'https://getpocket.com/explore/item/why-exhaustion-is-not-unique-to-our-overstimulated-age',
-    });
-
-    approvedItemCollection = await createApprovedItemHelper(db, {
-      title: 'Collection story one',
-      url: 'https://getpocket.com/collections/avocado-toast-was-king-these-recipes-are-vying-for-the-throne',
     });
   });
 
@@ -403,7 +388,6 @@ describe('CorpusItem reference resolver', () => {
     });
 
     it('handles repeat entities and sorts the results in order of the identifiers given', async () => {
-      console.log(approvedItem4);
       const result = await request(app)
         .post(graphQLUrl)
         .send({
@@ -442,214 +426,6 @@ describe('CorpusItem reference resolver', () => {
       verifyCorpusItemMetadata(result.body.data?._entities[1], approvedItem2);
       verifyCorpusItemMetadata(result.body.data?._entities[2], approvedItem3);
       verifyCorpusItemMetadata(result.body.data?._entities[3], approvedItem4);
-    });
-  });
-
-  describe('reference resolver for SavedItem', () => {
-    it('returns the corpus item if it exists on SavedItem', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'SavedItem',
-                url: approvedItem.url,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-
-      expect(result.body.data).not.toBeNull();
-      expect(result.body.data?._entities).toHaveLength(1);
-
-      verifyCorpusItemMetadata(
-        result.body.data?._entities[0].corpusItem,
-        approvedItem,
-      );
-    });
-
-    it('should return null on SavedItem if the url provided is not known', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'SavedItem',
-                url: 'ABRACADABRA',
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-      expect(result.body.data?._entities).toHaveLength(1);
-      expect(result.body.data?._entities[0].corpusItem).toBeNull();
-    });
-  });
-
-  describe('reference resolver for Item', () => {
-    it('returns the corpus item if it exists on Item', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'Item',
-                givenUrl: approvedItem.url,
-                resolvedUrl: approvedItem.url,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-
-      expect(result.body.data).not.toBeNull();
-      expect(result.body.data?._entities).toHaveLength(1);
-
-      verifyCorpusItemMetadata(
-        result.body.data?._entities[0].corpusItem,
-        approvedItem,
-      );
-    });
-    it('resolves the Item from resolvedUrl if givenUrl returns no record', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'Item',
-                givenUrl: 'https://www.youtube.com/watch?v=kfVsfOSbJY0',
-                resolvedUrl: approvedItem.url,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-
-      expect(result.body.data).not.toBeNull();
-      expect(result.body.data?._entities).toHaveLength(1);
-
-      verifyCorpusItemMetadata(
-        result.body.data?._entities[0].corpusItem,
-        approvedItem,
-      );
-    });
-
-    it('should return null on Item if the givenUrl and resolvedUrl provided are not known', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'Item',
-                givenUrl: 'ABRACADABRA',
-                resolvedUrl: 'ABRACADABRA',
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-      expect(result.body.data?._entities).toHaveLength(1);
-      expect(result.body.data?._entities[0].corpusItem).toBeNull();
-    });
-
-    it('should return null on Item if the givenUrl provided is not known and resolvedUrl is null', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'Item',
-                givenUrl: 'ABRACADABRA',
-                resolvedUrl: null,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-      expect(result.body.data?._entities).toHaveLength(1);
-      expect(result.body.data?._entities[0].corpusItem).toBeNull();
-    });
-  });
-
-  describe('target reference', () => {
-    it('returns the corpus target if its syndicated', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_TARGET_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'CorpusItem',
-                id: approvedItemSyndicated.externalId,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-
-      expect(result.body.data).not.toBeNull();
-      expect(result.body.data?._entities).toHaveLength(1);
-
-      expect(result.body.data?._entities[0].title).toEqual(
-        approvedItemSyndicated.title,
-      );
-      expect(result.body.data?._entities[0].target.slug).toEqual(
-        'why-exhaustion-is-not-unique-to-our-overstimulated-age',
-      );
-      expect(result.body.data?._entities[0].target.__typename).toEqual(
-        'SyndicatedArticle',
-      );
-    });
-
-    it('returns the corpus target if its collection', async () => {
-      const result = await request(app)
-        .post(graphQLUrl)
-        .send({
-          query: print(CORPUS_ITEM_TARGET_REFERENCE_RESOLVER),
-          variables: {
-            representations: [
-              {
-                __typename: 'CorpusItem',
-                id: approvedItemCollection.externalId,
-              },
-            ],
-          },
-        });
-
-      expect(result.body.errors).toBeUndefined();
-
-      expect(result.body.data).not.toBeNull();
-      expect(result.body.data?._entities).toHaveLength(1);
-      expect(result.body.data?._entities[0].title).toEqual(
-        approvedItemCollection.title,
-      );
-      expect(result.body.data?._entities[0].target.slug).toEqual(
-        'avocado-toast-was-king-these-recipes-are-vying-for-the-throne',
-      );
-      expect(result.body.data?._entities[0].target.__typename).toEqual(
-        'Collection',
-      );
     });
   });
 });

--- a/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/servers/curated-corpus-api/src/public/resolvers/queries/sample-queries.gql.ts
@@ -62,46 +62,6 @@ export const CORPUS_ITEM_REFERENCE_RESOLVER = gql`
           name
         }
       }
-      ... on SavedItem {
-        corpusItem {
-          id
-          title
-          authors {
-            name
-          }
-        }
-      }
-      ... on Item {
-        corpusItem {
-          id
-          title
-          authors {
-            name
-          }
-        }
-      }
-    }
-  }
-`;
-
-export const CORPUS_ITEM_TARGET_REFERENCE_RESOLVER = gql`
-  query ($representations: [_Any!]!) {
-    _entities(representations: $representations) {
-      ... on CorpusItem {
-        id
-        title
-        target {
-          __typename
-
-          ... on Collection {
-            slug
-          }
-
-          ... on SyndicatedArticle {
-            slug
-          }
-        }
-      }
     }
   }
 `;

--- a/servers/curated-corpus-api/src/shared/utils.spec.ts
+++ b/servers/curated-corpus-api/src/shared/utils.spec.ts
@@ -6,7 +6,6 @@ import {
   getScheduledSurfaceByAccessGroup,
   getScheduledSurfaceByGuid,
   toUtcDateString,
-  getPocketPath,
   getNormalizedDomainFromUrl,
   getRegistrableDomainFromUrl,
   getLocalDate,
@@ -136,80 +135,6 @@ describe('shared/utils', () => {
       expect(result.imageUrl).toEqual(approvedItem.imageUrl);
       expect(result.topic).toEqual(approvedItem.topic);
       expect(result.isTimeSensitive).toEqual(approvedItem.isTimeSensitive);
-    });
-  });
-
-  describe('getPocketPath', () => {
-    it('matches syndicated articles without locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/explore/item/foo-bar'),
-      ).toEqual({
-        locale: null,
-        path: '/explore/item/foo-bar',
-        type: 'SyndicatedArticle',
-        key: 'foo-bar',
-      });
-    });
-    it('matches syndicated articles with two character locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/de/explore/item/foo-bar'),
-      ).toEqual({
-        locale: 'de',
-        path: '/explore/item/foo-bar',
-        type: 'SyndicatedArticle',
-        key: 'foo-bar',
-      });
-    });
-    it('matches syndicated articles with five character locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/en-GB/explore/item/foo-bar'),
-      ).toEqual({
-        locale: 'en-GB',
-        path: '/explore/item/foo-bar',
-        type: 'SyndicatedArticle',
-        key: 'foo-bar',
-      });
-    });
-    it('matches collections without locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/collections/foo-bar'),
-      ).toEqual({
-        locale: null,
-        path: '/collections/foo-bar',
-        type: 'Collection',
-        key: 'foo-bar',
-      });
-    });
-    it('matches collections articles with two character locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/de/collections/foo-bar'),
-      ).toEqual({
-        locale: 'de',
-        path: '/collections/foo-bar',
-        type: 'Collection',
-        key: 'foo-bar',
-      });
-    });
-    it('matches collections articles with five character locale', () => {
-      expect(
-        getPocketPath('https://getpocket.com/en-GB/collections/foo-bar'),
-      ).toEqual({
-        locale: 'en-GB',
-        path: '/collections/foo-bar',
-        type: 'Collection',
-        key: 'foo-bar',
-      });
-    });
-    it('doesnt match other pocket urls', () => {
-      expect(getPocketPath('https://getpocket.com/saves')).toEqual({
-        locale: null,
-        path: '/saves',
-      });
-      expect(getPocketPath('https://getpocket.com')).toEqual({
-        locale: null,
-        path: '/',
-      });
-      expect(getPocketPath('https://other.com')).toBeNull();
     });
   });
 

--- a/servers/curated-corpus-api/src/shared/utils.ts
+++ b/servers/curated-corpus-api/src/shared/utils.ts
@@ -1,8 +1,8 @@
 import { UserInputError } from '@pocket-tools/apollo-utils';
 import { ScheduledSurface, ScheduledSurfaces } from 'content-common';
-import { ApprovedItem, CorpusItem, CorpusTargetType } from '../database/types';
+import { ApprovedItem, CorpusItem } from '../database/types';
 import { ApprovedItemAuthor } from 'content-common';
-import { domainToASCII, parse } from 'url';
+import { domainToASCII } from 'url';
 import { parse as parseDomain, getDomain } from 'tldts';
 import { DateTime } from 'luxon';
 
@@ -83,8 +83,6 @@ export const getScheduledSurfaceByGuid = (
 export const getCorpusItemFromApprovedItem = (
   approvedItem: ApprovedItem,
 ): CorpusItem => {
-  const target = getPocketPath(approvedItem.url);
-
   return {
     id: approvedItem.externalId,
     url: approvedItem.url,
@@ -106,88 +104,9 @@ export const getCorpusItemFromApprovedItem = (
     // JS reason? or is it just better practice?
     topic: approvedItem.topic ?? undefined,
     isTimeSensitive: approvedItem.isTimeSensitive,
-    target: target?.key && {
-      slug: target.key,
-      __typename: target.type,
-    },
   };
 };
 // End Pocket shared data utility constructs/functions
-
-const slugRegex = /[\w/]+\/([\w-]+)$/;
-const localeRegex = /\/([a-z]{2}(-[A-Z]{2})?)(\/.*)/;
-
-/**
- *
- * @param path
- * @returns [locale, path]
- */
-const dropUrlLocalePath = (path: string): [string, string] => {
-  const match = path.match(localeRegex);
-
-  if (!match || match.length < 3) {
-    return [null, path];
-  }
-
-  return [match[1], match[3]];
-};
-
-/**
- *
- * @param path without locale.
- * @returns
- */
-const getUrlType = (path: string): CorpusTargetType => {
-  if (path.startsWith('/explore/item/')) {
-    return 'SyndicatedArticle';
-  } else if (path.startsWith('/collections/')) {
-    return 'Collection';
-  }
-  return null;
-};
-
-export const getUrlId = (path: string): string => {
-  return path.match(slugRegex)[1];
-};
-
-/**
- *
- * @param url Fully qualified URL.
- * @returns {locale, path, type, key} when URL has a known entity type.
- *          {locale, path} when its a pocket URL but the entities are not known.
- */
-export const getPocketPath = (
-  url: string,
-): {
-  locale: string;
-  path: string;
-  type?: CorpusTargetType;
-  key?: string;
-} => {
-  const obj = parse(url, true);
-
-  // Guard, only process getpocket.com urls.
-  if (obj.host != 'getpocket.com') {
-    return null;
-  }
-
-  // Drop the locale prefix from the path.
-  const [locale, path] = dropUrlLocalePath(obj.pathname);
-  const type = getUrlType(path);
-
-  if (type == null) {
-    return { locale, path };
-  }
-
-  const key = getUrlId(path);
-
-  return {
-    locale,
-    path,
-    type,
-    key,
-  };
-};
 
 /**
  * Normalizes a domain string by lowercasing, converting to ASCII (punycode),


### PR DESCRIPTION
## Goal

remove references to legacy types and related resolver/test code. part 2 of change started in https://github.com/Pocket/pocket-monorepo/pull/1110

- remove Item, SavedItem, SyndicatedArticle, and Collection

the graph changes here have been pushed to dev.

## Deployment steps

- [ ] Delete legacy subgraphs from prod
- [x] Deployed to dev?
- [x] Legacy subgraphs deleted from dev?

## References

JIRA ticket:

- [HNT-1542](https://mozilla-hub.atlassian.net/browse/HNT-1542)


[HNT-1542]: https://mozilla-hub.atlassian.net/browse/HNT-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ