### PR TITLE
chore: remove Item and SavedItem references from corpus API subgraph

### DIFF
--- a/servers/curated-corpus-api/schema-public.graphql
+++ b/servers/curated-corpus-api/schema-public.graphql
@@ -147,33 +147,3 @@ type Query {
   """
   getSections(filters: SectionFilters!): [Section!]!
 }
-
-type SavedItem @key(fields: "url") {
-  """
-  key field to identify the SavedItem entity in the ListApi service
-  """
-  url: String!
-
-  """
-  If the item is in corpus allow the saved item to reference it.  Exposing curated info for consistent UX
-  """
-  corpusItem: CorpusItem
-}
-
-type Item @key(fields: "givenUrl") {
-  """
-  key field to identify the CorpusItem entity in the RecsAPI service
-  """
-  givenUrl: Url!
-
-  """
-  Resolved URL field from the Parser in order to identify a given URL
-  in the Corpus (fallback if givenUrl is insufficient)
-  """
-  resolvedUrl: Url @external
-
-  """
-  If the item is in corpus allow the item to reference it.  Exposing curated info for consistent UX
-  """
-  corpusItem: CorpusItem @requires(fields: "resolvedUrl")
-}


### PR DESCRIPTION
- this will let us delete the parser subgraph

## Goal

What changed? What is the business/product goal?

- Change 1
- Change 2

## I'd love feedback/perspectives on:

-

## Implementation Decisions

-

## Deployment steps

- [ ] Database migrations?
- [ ] Deployed to dev?
- [ ] Secrets?

## References

JIRA ticket:

- Link to JIRA ticket

Issue:

- Link to GitHub issue

Documentation:

- Project doc
