### PR TITLE
chore(logging): send actual error to sentry when S3 upload fails

### DIFF
--- a/servers/curated-corpus-api/src/admin/aws/upload.ts
+++ b/servers/curated-corpus-api/src/admin/aws/upload.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { v4 as uuidv4 } from 'uuid';
 import mime from 'mime-types';
 import { S3Client } from '@aws-sdk/client-s3';
@@ -40,6 +41,9 @@ export async function getS3UrlForImageUrl(
 
       s3ImageUrl = upload.url;
     } catch (err) {
+      Sentry.captureException(err, {
+        extra: { imageUrl },
+      });
       s3ImageUrl = null;
     }
   }


### PR DESCRIPTION
## Goal

adds a sentry call to log the actual error when an S3 upload fails. (we're getting hundreds of these errors per day atm...)

## References

JIRA ticket: [HNT-2796](https://mozilla-hub.atlassian.net/browse/HNT-2796)

[HNT-2796]: https://mozilla-hub.atlassian.net/browse/HNT-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ