### PR TITLE
chore(logging): add content type to error when S3 upload fails

### DIFF
--- a/servers/curated-corpus-api/src/admin/aws/upload.integration.ts
+++ b/servers/curated-corpus-api/src/admin/aws/upload.integration.ts
@@ -96,7 +96,7 @@ describe('Upload', () => {
         uploadImageToS3FromUrl(s3, 'https://some.external.domain/image.jpg'),
       ).rejects.toThrow(
         new Error(
-          `Unknown/unexpected content-type for image: https://some.external.domain/image.jpg`,
+          `Unknown/unexpected content-type (text/javascript) for image: https://some.external.domain/image.jpg`,
         ),
       );
 

--- a/servers/curated-corpus-api/src/admin/aws/upload.ts
+++ b/servers/curated-corpus-api/src/admin/aws/upload.ts
@@ -69,7 +69,9 @@ export async function uploadImageToS3FromUrl(
 
   // make sure we have an image
   if (contentType === undefined || !contentType.startsWith('image/')) {
-    throw new Error(`Unknown/unexpected content-type for image: ${imageUrl}`);
+    throw new Error(
+      `Unknown/unexpected content-type (${contentType}) for image: ${imageUrl}`,
+    );
   }
 
   const key = `${uuidv4()}.${mime.extension(contentType)}`;


### PR DESCRIPTION
## Goal

add a bit more content - the `content-type` header value - to error message when S3 image upload fails.

## References

JIRA ticket:

- [HNT-2796](https://mozilla-hub.atlassian.net/browse/HNT-2796)

[HNT-2796]: https://mozilla-hub.atlassian.net/browse/HNT-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ