### PR TITLE
feat: improve fetchUrlMetadata error handling & reporting

### DIFF
--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.spec.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.spec.ts
@@ -1,11 +1,17 @@
+import * as Sentry from '@sentry/node';
+
 import { parse } from 'tldts';
 
 import {
   convertParserJsonToUrlMetadata,
   deriveAuthors,
   deriveDatePublished,
+  fetchUrlMetadata,
   validateUrl,
 } from './lib';
+
+// mock sentry
+jest.mock('@sentry/node');
 
 describe('lib', () => {
   describe('convertParserJsonToUrlMetadata', () => {
@@ -279,5 +285,176 @@ describe('lib', () => {
         expect(validateUrl(validUrl)).toBe(true);
       },
     );
+  });
+
+  describe('fetchUrlMetadata', () => {
+    let mockSentryCaptureException: jest.Mock;
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    beforeAll(() => {
+      mockSentryCaptureException = Sentry.captureException as jest.Mock;
+    });
+
+    it('returns expected json on successful fetch', async () => {
+      const jsonResponse = {
+        statusCode: 200,
+        article: {
+          title: 'test article',
+        },
+      };
+
+      jest.spyOn(global, 'fetch').mockImplementation(
+        jest.fn(() =>
+          Promise.resolve({
+            // return data doesn't matter for this test
+            json: () => Promise.resolve(jsonResponse),
+            ok: true,
+          }),
+        ) as jest.Mock,
+      );
+
+      const json = await fetchUrlMetadata(
+        'https://test.com',
+        'https://metadataendpoint.test/',
+        'fakeApiKey',
+      );
+
+      expect(json).toEqual(jsonResponse);
+    });
+
+    it('returns empty object and calls sentry if fetch fails', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(() => Promise.reject('fetch error!'));
+
+      const json = await fetchUrlMetadata(
+        'https://test.com',
+        'https://metadataendpoint.test/',
+        'fakeApiKey',
+      );
+
+      // make sure an empty object was returned
+      expect(json).toEqual({});
+
+      // make sure sentry was called as expected
+      expect(mockSentryCaptureException).toHaveBeenCalledWith('fetch error!', {
+        extra: {
+          message: `Metadata parser general fetch failure`,
+          url: 'https://test.com',
+        },
+      });
+    });
+
+    it('returns empty object and calls sentry if response is not ok', async () => {
+      jest.spyOn(global, 'fetch').mockImplementation(
+        jest.fn(() =>
+          Promise.resolve({
+            text: () => Promise.resolve('some error'),
+            ok: false,
+            status: 500,
+          }),
+        ) as jest.Mock,
+      );
+
+      const json = await fetchUrlMetadata(
+        'https://test.com',
+        'https://metadataendpoint.test/',
+        'fakeApiKey',
+      );
+
+      // make sure an empty object was returned
+      expect(json).toEqual({});
+
+      // make sure sentry was called as expected
+      expect(mockSentryCaptureException).toHaveBeenCalledWith(
+        new Error('Metadata parser returned non-2xx HTTP status'),
+        {
+          extra: {
+            status: 500,
+            url: 'https://test.com',
+            responseBody: 'some error',
+          },
+        },
+      );
+    });
+
+    it('returns empty object and calls sentry if json parsing fails', async () => {
+      jest.spyOn(global, 'fetch').mockImplementation(
+        jest.fn(() =>
+          Promise.resolve({
+            // make sure json parsing fails
+            json: () => Promise.reject('i am decidedly not json!'),
+            ok: true,
+          }),
+        ) as jest.Mock,
+      );
+
+      const json = await fetchUrlMetadata(
+        'https://test.com',
+        'https://metadataendpoint.test/',
+        'fakeApiKey',
+      );
+
+      // make sure an empty object was returned
+      expect(json).toEqual({});
+
+      // make sure sentry was called as expected
+      expect(mockSentryCaptureException).toHaveBeenCalledWith(
+        'i am decidedly not json!',
+        {
+          extra: {
+            message: `Metadata parser JSON response failure`,
+            url: 'https://test.com',
+          },
+        },
+      );
+    });
+
+    it('returns expected json and calls sentry if statusCode is >= 400', async () => {
+      const jsonResponse = {
+        // zyte's API could not find the URL requested, but still returns
+        // a 200 HTTP response. the 404 is reported in the API response.
+        // i.e. the call to zyte succeeds, but it was unable to retrieve
+        // metadata for the given url.
+        statusCode: 404,
+        article: {},
+      };
+
+      jest.spyOn(global, 'fetch').mockImplementation(
+        jest.fn(() =>
+          Promise.resolve({
+            json: () => Promise.resolve(jsonResponse),
+            ok: true,
+          }),
+        ) as jest.Mock,
+      );
+
+      const json = await fetchUrlMetadata(
+        'https://test.com',
+        'https://metadataendpoint.test/',
+        'fakeApiKey',
+      );
+
+      // make sure expected object was returned
+      expect(json).toEqual(jsonResponse);
+
+      // make sure sentry was called as expected
+      expect(mockSentryCaptureException).toHaveBeenCalledWith(
+        new Error(`Metadata parser failed to parse given url.`),
+        {
+          extra: {
+            url: 'https://test.com',
+            status: json.statusCode,
+          },
+        },
+      );
+    });
   });
 });

--- a/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.ts
+++ b/servers/curated-corpus-api/src/admin/resolvers/queries/UrlMetadata/lib.ts
@@ -80,25 +80,24 @@ export const deriveDatePublished = (dateRaw: any): string | undefined => {
  * broken out into a standalone function for easier mocking in tests.
  *
  * @param url URL for which to fetch metadata
- * @param metadataParserEnpointUrl URL endpoint of the metadata service
+ * @param metadataParserEndpointUrl URL endpoint of the metadata service
  * @param metadataParserApiKey API key for the metadata service
  * @returns JSON from the metadata service, or an empty object on failure
  */
 export const fetchUrlMetadata = async (
   url: string,
-  metadataParserEnpointUrl: string,
+  metadataParserEndpointUrl: string,
   metadataParserApiKey: string,
 ): Promise<{ [key: string]: any }> => {
   // Zyte-specific implementation
+
+  // default response - empty object
+  let json: { [key: string]: any } = {};
+  let fetchResponse: Response | undefined = undefined;
+
+  // 1. attempt to fetch metadata from zyte
   try {
-    const response = await fetch(metadataParserEnpointUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Basic ${Buffer.from(
-          metadataParserApiKey + ':',
-        ).toString('base64')}`,
-      },
+    fetchResponse = await fetch(metadataParserEndpointUrl, {
       body: JSON.stringify({
         url: url,
         article: true,
@@ -110,16 +109,75 @@ export const fetchUrlMetadata = async (
           service: config.app.serviceName,
         },
       }),
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${Buffer.from(
+          metadataParserApiKey + ':',
+        ).toString('base64')}`,
+      },
+      method: 'POST',
+      signal: AbortSignal.timeout(config.metadataParser.timeout),
     });
 
-    return await response.json();
+    // if the fetch gave us a non-2xx response, send to sentry.
+    // this will result in an empty object returned to the caller.
+    if (!fetchResponse.ok) {
+      // if response is not ok, try to capture the body of the response, as it
+      // may hold important error info.
+      const responseBody = await fetchResponse.text().catch(() => undefined);
+
+      Sentry.captureException(
+        new Error(`Metadata parser returned non-2xx HTTP status`),
+        {
+          extra: {
+            status: fetchResponse.status,
+            url,
+            responseBody,
+          },
+        },
+      );
+    }
   } catch (e) {
-    Sentry.captureException(
-      new Error(`Metadata parser failed to return metadata for ${url}`),
-    );
-    // gracefully return empty object when external metadata parser fails
-    return {};
+    // if any error occurred above, send it to sentry
+    Sentry.captureException(e, {
+      extra: {
+        message: `Metadata parser general fetch failure`,
+        url,
+      },
+    });
   }
+
+  // 2. if we successfully fetched data from zyte, attempt to get the JSON.
+  if (fetchResponse && fetchResponse.ok) {
+    try {
+      json = await fetchResponse.json();
+    } catch (e) {
+      Sentry.captureException(e, {
+        extra: {
+          message: `Metadata parser JSON response failure`,
+          url,
+        },
+      });
+    }
+  }
+
+  // 3. zyte's response may be a 2xx, with valid JSON, but there still may be
+  // an issue with the url attempted to be scraped.
+  // https://docs.zyte.com/zyte-api/usage/reference.html#operation/extract/response/200/statusCode
+  if (json.statusCode >= 400) {
+    Sentry.captureException(
+      new Error(`Metadata parser failed to parse given url.`),
+      {
+        extra: {
+          url,
+          status: json.statusCode,
+        },
+      },
+    );
+  }
+
+  // 4. return the json from zyte, or an empty object.
+  return json;
 };
 
 /**

--- a/servers/curated-corpus-api/src/config/index.ts
+++ b/servers/curated-corpus-api/src/config/index.ts
@@ -61,6 +61,10 @@ export default {
   metadataParser: {
     endpoint: process.env.ZYTE_EXTRACT_API_ENDPOINT || '',
     apiKey: process.env.ZYTE_EXTRACT_API_KEY || '',
+    // zyte calls generally take between 7 and 10 seconds to complete -
+    // 25 seconds should be generous enough here to allow calls to finish
+    // and not get us caught in long timeout errors
+    timeout: 25000,
   },
   sentry: {
     dsn: process.env.SENTRY_DSN || '',

--- a/servers/curated-corpus-api/tsconfig.json
+++ b/servers/curated-corpus-api/tsconfig.json
@@ -4,12 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "exclude": [
-    "node_modules/",
-    "dist/"
-  ],
-  "include": [
-    "src/**/*.ts",
-  ]
+  "exclude": ["node_modules/", "dist/"],
+  "include": ["src/**/*.ts"]
 }
-


### PR DESCRIPTION
## Goal

add better error handling and logging when fetching metadata from zyte.

been running on dev since last night and (after increasing timeout from 15s to 25s), no issues have arisen.

## Deployment steps

- [x] Deployed to dev?

## References

JIRA ticket:

- [HNT-2442](https://mozilla-hub.atlassian.net/browse/HNT-2442)

[HNT-2442]: https://mozilla-hub.atlassian.net/browse/HNT-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ